### PR TITLE
move keep_dims_ind helper functions to be defined before generated function

### DIFF
--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -215,8 +215,11 @@ function unify_names_longest(names_a, names_b)
     return compile_time_return_hack(ret)
 end
 
-keep_dim_ind_type(::Type{<:Integer}) = false
-keep_dim_ind_type(::Any) = true
+# The following are helpers for remaining_dimnames_from_indexing
+# as a generated function it can get unhappy if asked to use anon functions
+# and it can only call function declared before it. So we declare them explictly here.
+is_noninteger_type(::Type{<:Integer}) = false
+is_noninteger_type(::Any) = true
 
 """
     remaining_dimnames_from_indexing(dimnames::Tuple, inds...)
@@ -229,7 +232,7 @@ Dimensions indexed with scalars are dropped
     # 0-Allocation see:
     # `@btime (()->remaining_dimnames_from_indexing((:a, :b, :c), (:,390,:)))()``
     ind_types = inds.parameters
-    kept_dims = findall(keep_dim_ind_type, ind_types)
+    kept_dims = findall(is_noninteger_type, ind_types)
     keep_names = [:(getfield(dimnames, $ii)) for ii in kept_dims]
     return Expr(:call, :compile_time_return_hack, Expr(:tuple, keep_names...))
 end

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -215,6 +215,8 @@ function unify_names_longest(names_a, names_b)
     return compile_time_return_hack(ret)
 end
 
+keep_dim_ind_type(::Type{<:Integer}) = false
+keep_dim_ind_type(::Any) = true
 
 """
     remaining_dimnames_from_indexing(dimnames::Tuple, inds...)
@@ -231,8 +233,6 @@ Dimensions indexed with scalars are dropped
     keep_names = [:(getfield(dimnames, $ii)) for ii in kept_dims]
     return Expr(:call, :compile_time_return_hack, Expr(:tuple, keep_names...))
 end
-keep_dim_ind_type(::Type{<:Integer}) = false
-keep_dim_ind_type(::Any) = true
 
 
 """


### PR DESCRIPTION
It is a rule of generated functions that they can only call things defined before their own definition.
So depending on the order of function calls without this change world-age `MethodError`s can be thrown.