### PR TITLE
[speculative] Use Base.names

### DIFF
--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -49,10 +49,10 @@ macro declare_matmul(MatrixT, VectorT=nothing)
 
         quote
             function Base.:*(a::$TA_named, b::$TB_other)
-                return *(a, NamedDims.NamedDimsArray{NamedDims.names(b)}(b))
+                return *(a, NamedDims.NamedDimsArray{names(b)}(b))
             end
             function Base.:*(a::$TA_other, b::$TB_named)
-                return *(NamedDims.NamedDimsArray{NamedDims.names(a)}(a), b)
+                return *(NamedDims.NamedDimsArray{names(a)}(a), b)
             end
         end
     end

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -67,9 +67,10 @@ Base.parent(x::NamedDimsArray) = x.data
 
 Returns a tuple of containing the names of all the dimensions of the array `A`.
 """
-names(::Type{<:NamedDimsArray{L}}) where L = L
-names(::Type{<:AbstractArray{T, N}}) where {T,N} = ntuple(_->:_, N)
-names(x::T) where T<:AbstractArray = names(T)
+Base.names(::Type{<:NamedDimsArray{L}}) where L = L
+Base.names(::Type{<:AbstractArray{T, N}}) where {T,N} = ntuple(_->:_, N)
+Base.names(x::T) where T<:AbstractArray = names(T)
+# Note: the above is type-piracy
 
 dim(a::NamedDimsArray{L}, name) where L = dim(L, name)
 

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -1,5 +1,4 @@
 using NamedDims
-using NamedDims: names
 using Test
 using Tracker
 

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -1,5 +1,4 @@
 using NamedDims
-using NamedDims: names
 using Test
 using Tracker
 using Tracker: data, TrackedReal

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,5 +1,4 @@
 using NamedDims
-using NamedDims: names
 using Test
 using Statistics
 

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -1,5 +1,4 @@
 using NamedDims
-using NamedDims: names
 using Test
 
 @testset "rename" begin

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 using NamedDims
-using NamedDims: matrix_prod_names, names
+using NamedDims: matrix_prod_names
 using Test
 
 @testset "+" begin

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -1,9 +1,6 @@
 using NamedDims
-using NamedDims: names
 using SparseArrays
 using Test
-
-
 
 @testset "get the parent array that was wrapped" begin
     orig = [1 2; 3 4]


### PR DESCRIPTION
Closes #22

However, right now this means doing type-piracy,
to make `Base.names(::AbstractArray) = (:_, :_)`
This can (and should) be removed,
it is only really used in a few places, and we can have a internal `_names` if we really nead it.

However, this approach is basically mutally exclusive with #20 
as that actually requires attacheding `names` to `AbstractArray`s.
Though perhaps it can be done in a type-parametric way that avoids type-piracy?