### PR TITLE
[WIP] add lmul!

### DIFF
--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -147,3 +147,14 @@ end
         @test names(nda * x) == (:a, :_)
     end
 end
+
+
+@testset "mldivide" begin
+    outputs = NamedDimsArray{(:variates, :observations)}(randn(3, 10))
+    inputs = NamedDimsArray{(:features, :observations)}(rand(4, 10))
+
+    # outputs = mapping * inputs
+    mapping = outputs / inputs
+
+    @test names(mapping) == (:variates, :features)
+end


### PR DESCRIPTION
This PR adds `lmul!`
I am not particularly happy about it, 
as I don't think it does so in a consistent way.
It doesn't yet handle the scalar case
also it the RHS is not a `NamedDimsArray`
and the LHS is
then this will return a NamedDImsArray,
even though the mutated RHS, is of course still its original type.
Which kinda annoys me, though a lot of the linear algebra code does this.

If this PR is combined with #24 
then `A\B` works, though it wildcards both its names so not very useful.