### PR TITLE
Add Strided Array Interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -2,16 +2,15 @@
 
 ## Helpers:
 
-# if reducing over `:` then results is a scalar
-function nameddimsarray_result(original_nda, reduced_data, reduction_dims::Colon)
-    return reduced_data
-end
-
 function nameddimsarray_result(original_nda, reduced_data, reduction_dims)
     L = dimnames(original_nda)
     return NamedDimsArray{L}(reduced_data)
 end
 
+# if reducing over `:` then results is a scalar
+function nameddimsarray_result(original_nda, reduced_data, reduction_dims::Colon)
+    return reduced_data
+end
 
 ################################################
 # Overloads

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -2,15 +2,16 @@
 
 ## Helpers:
 
+# if reducing over `:` then results is a scalar
+function nameddimsarray_result(original_nda, reduced_data, reduction_dims::Colon)
+    return reduced_data
+end
+
 function nameddimsarray_result(original_nda, reduced_data, reduction_dims)
     L = dimnames(original_nda)
     return NamedDimsArray{L}(reduced_data)
 end
 
-# if reducing over `:` then results is a scalar
-function nameddimsarray_result(original_nda, reduced_data, reduction_dims::Colon)
-    return reduced_data
-end
 
 ################################################
 # Overloads

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -106,6 +106,13 @@ function Base.similar(
     return similar(a, eltype, dims)
 end
 
+#####################################
+# Strided Array interface
+Base.stride(a::NamedDimsArray, k::Symbol) = stride(parent(a), dim(a, k))
+Base.stride(a::NamedDimsArray, k::Integer) = stride(parent(a), k)
+Base.strides(a::NamedDimsArray) = strides(parent(a))
+
+
 ###############################
 # kwargs indexing
 

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -148,9 +148,10 @@ end
 end
 
 @testset "Strided Array Interface" begin
-    nda = NamedDimsArray{(:a, :b)}(ones(3,5))
-    @test strides(nda) == (1, 3)
-    @test stride(nda, :b) == 3 == stride(nda, 2)
+    x = ones(3, 5)
+    nda = NamedDimsArray{(:a, :b)}(x)
+    @test strides(nda) == (1, 3) == strides(x)
+    @test stride(nda, :b) == 3 == stride(nda, 2) == stride(x, 2)
 end
 
 const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -147,6 +147,11 @@ end
     end
 end
 
+@testset "Strided Array Interface" begin
+    nda = NamedDimsArray{(:a, :b)}(ones(3,5))
+    @test strides(nda) == (1, 3)
+    @test stride(nda, :b) == 3 == stride(nda, 2)
+end
 
 const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
 @testset "allocations: wrapper" begin


### PR DESCRIPTION
Because right now StridedArray is a  Union and thus not extensible
(see https://github.com/JuliaLang/julia/pull/30432)
you don't need to implement `strides` explictly for all new strided array types,
which we can assume (and then be proven wrong with later method errors) 
that our wrapped type is.

This is needed for some BLAS stuff called by Distributions.jl