### PR TITLE
RFC: upstairs & downstairs

### DIFF
--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -2,16 +2,16 @@
 
 # Up/downstairs: indicated by sentinel characters
 export up, down
-up(s) = Symbol('♂',s)   # these parse as letters, and can be typed as \male, \female
-down(s) = Symbol('♀',s) # other options... ⬆️⬇️ can't be typed & overlap next char
+up(s) = Symbol(s,'♯')
+down(s) = Symbol(s,'♭')
 
 up(a::NamedDimsArray{L}) where {L} = NamedDimsArray(parent(a), map(up, L))
 down(a::NamedDimsArray{L}) where {L} = NamedDimsArray(parent(a), map(down, L))
 
 function unpack_updown(a::Symbol)
-    a1 = first(string(a))
-    a1==='♂' && return 1, string(a)[4:end] # nextind(string(up(:a)),1) == 4
-    a1==='♀' && return -1, string(a)[4:end]
+    a1 = last(string(a))
+    a1==='♯' && return 1, string(a)[1:end-1]
+    a1==='♭' && return -1, string(a)[1:end-1]
     return 0, string(a)
 end
 


### PR DESCRIPTION
This is a first attempt at adding support for co- & contravariant indices. 

The idea is to add some sentinel character to the symbol naming a dimension, to mark it as up- or down-stairs. Symbols without such a marking will be treated as neutral. The rule is that, if we contract two dimensions both of which are marked, then one must be up and one down, in addition to the names agreeing. 

Here's how `dot` works: 
```julia
julia> va = NamedDimsArray(rand(1:9,4),(:a));

julia> vb = NamedDimsArray(rand(1:9,4),(:b));

julia> up(va)
4-element NamedDimsArray{(:a♯,),Int64,1,Array{Int64,1}}:
 1
 3
 7
 5

julia> dot(up(va), down(va))  # this is V^a V_a
84

julia> dot(up(va), va) # here the 2nd vector is neutral, indifferent
84

julia> dot(up(va), up(va))   # this is V^a V^a which is illegal
ERROR: DimensionMismatch("Cannot take dot of vectors with incompatible dimension names. (:a♯,) vs (:a♯,)")
```

And `*`:
```julia
julia> mab = up(va) * down(vb)'  # matrix M^a_b = V^a V_b
4×4 NamedDimsArray{(:a♯, :b♭),Int64,2,Array{Int64,2}}:
  6   3   4   9
 18   9  12  27
 42  21  28  63
 30  15  20  45

julia> mab * up(vb)              # M^a_b V^b  is legal
4-element NamedDimsArray{(:a♯,),Int64,1,Array{Int64,1}}:
 142
 426
 994
 710

julia> mab * down(vb)            # M^a_b V_b  is illegal
ERROR: DimensionMismatch("Cannot take matrix product of arrays with different inner dimension names. (:a♯, :b♭) vs (:b♭,)")
```

The downside is that this has to take the symbols apart to see what the last character is, which is slower than comparing symbols. And this cost is paid even for names which don't opt-in to being up/down, as we still need to first check that. Unless there is some smarter way to do this?
```julia
julia> @btime NamedDims.valid_updown(:_, :a)
  0.027 ns (0 allocations: 0 bytes)
true

julia> @btime NamedDims.valid_updown(upa, downa)  setup = (upa = up(:a); downa = down(:a))
  317.315 ns (16 allocations: 768 bytes)
true

julia> @btime NamedDims.valid_updown(:a, :b)
  252.142 ns (14 allocations: 704 bytes)
false
```
But only for contracting operations like `dot`, `*` (and I guess `inv`, `adjoint`). Other things like broadcasting need not care. 

The more complicated solution would be to make the indices some struct with a flag plus a name, the flag could even be in the type e.g. `(name=:a, position=^)`, `(name=:b, position=/)`. Or I see you said you had things working for any bitstype, so it could be as simple as a tuple,  `isbits(Tuple(collect("a♯"))) == true`.