### PR TITLE
Correct names for single input cov/cor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -22,7 +22,7 @@ for (mod, funs) in (
         :sum, :prod, :count, :maximum, :minimum, :extrema, :cumsum, :cumprod,
         :sort, :sort!,)
     ),
-    (:Statistics, (:mean, :std, :var, :median, :cov, :cor)),
+    (:Statistics, (:mean, :std, :var, :median)),
 )
     for fun in funs
         @eval function $mod.$fun(a::NamedDimsArray; dims=:, kwargs...)
@@ -74,5 +74,3 @@ for (mod, funs) in (
         end
     end
 end
-
-

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -67,3 +67,25 @@ function Base.inv(nda::NamedDimsArray{L, T, 2}) where {L,T}
     names = reverse(L)
     return NamedDimsArray{names}(data)
 end
+
+# Statistics
+for fun in (:cor, :cov)
+    @eval function Statistics.$fun(a::NamedDimsArray{L, T, 2}; dims=1, kwargs...) where {L, T}
+        numerical_dims = dim(a, dims)
+        data = Statistics.$fun(parent(a); dims=numerical_dims, kwargs...)
+        names = symmetric_names(L, numerical_dims)
+        return NamedDimsArray{names}(data)
+    end
+end
+
+function symmetric_names(L::Tuple{Symbol,Symbol}, dims::Integer)
+    # 0 Allocations. See `@btime (()-> symmetric_names((:foo, :bar), 1))()`
+    names = if dims == 1
+        (L[2], L[2])
+    elseif dims == 2
+        (L[1], L[1])
+    else
+        (:_, :_)
+    end
+    compile_time_return_hack(names)
+end

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -19,7 +19,7 @@ function matrix_prod_names(a, b)
             "Cannot take matrix product of arrays with different inner dimension names. $a vs $b"
         ))
     res = matmul_names(a, b)
-    compile_time_return_hack(res)
+    return compile_time_return_hack(res)
 end
 
 
@@ -87,5 +87,5 @@ function symmetric_names(L::Tuple{Symbol,Symbol}, dims::Integer)
     else
         (:_, :_)
     end
-    compile_time_return_hack(names)
+    return compile_time_return_hack(names)
 end

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -155,14 +155,14 @@ end
     @test inv(nda) * nda ≈ NamedDimsArray{(:b, :b)}([1.0 0; 0 1])
 end
 
-@testset "symmetric results" begin
-    @testset "symmetric_names" begin
-        @test symmetric_names((:a, :b), 1) == (:b, :b)
-        @test symmetric_names((:a, :b), 2) == (:a, :a)
-        @test symmetric_names((:a, :b), 5) == (:_, :_)
-        @test_throws MethodError symmetric_names((:a, :b, :c), 2)
-    end
-    @testset "$f" for f in (cov, cor)
+@testset "symmetric_names" begin
+    @test symmetric_names((:a, :b), 1) == (:b, :b)
+    @test symmetric_names((:a, :b), 2) == (:a, :a)
+    @test symmetric_names((:a, :b), 5) == (:_, :_)
+    @test_throws MethodError symmetric_names((:a, :b, :c), 2)
+end
+@testset "$f" for f in (cov, cor)
+    @testset "matrix input, matrix result" begin
         A = rand(3, 5)
         nda = NamedDimsArray{(:a, :b)}(A)
         @test f(nda; dims=:a) == f(A, dims=1)
@@ -170,5 +170,14 @@ end
         @test names(f(nda, dims=:b)) == (:a, :a)
         # `Statistic.cov(A, dims=p)` for `p > 2` is allowed but returns NaNs. Same for `cor`.
         @test names(f(nda, dims=3)) == (:_, :_)
+    end
+    @testset "vector input, scalar result" begin
+        a = rand(4)
+        nda = NamedDimsArray{(:a,)}(a)
+        @test f(nda) isa Number
+        @test f(nda) == f(a)
+    end
+    @testset "high dimensional input" begin
+        @test_throws MethodError f(NamedDimsArray(rand(3, 4, 5), (:a, :b, :c)))
     end
 end

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 using NamedDims
-using NamedDims: matrix_prod_names, names
+using NamedDims: matrix_prod_names, names, symmetric_names
 using Test
 
 @testset "+" begin
@@ -153,4 +153,22 @@ end
     @test names(inv(nda)) == (:b, :a)
     @test nda * inv(nda) ≈ NamedDimsArray{(:a, :a)}([1.0 0; 0 1])
     @test inv(nda) * nda ≈ NamedDimsArray{(:b, :b)}([1.0 0; 0 1])
+end
+
+@testset "symmetric results" begin
+    @testset "symmetric_names" begin
+        @test symmetric_names((:a, :b), 1) == (:b, :b)
+        @test symmetric_names((:a, :b), 2) == (:a, :a)
+        @test symmetric_names((:a, :b), 5) == (:_, :_)
+        @test_throws MethodError symmetric_names((:a, :b, :c), 2)
+    end
+    @testset "$f" for f in (cov, cor)
+        A = rand(3, 5)
+        nda = NamedDimsArray{(:a, :b)}(A)
+        @test f(nda; dims=:a) == f(A, dims=1)
+        @test names(f(nda; dims=:a)) == (:b, :b)
+        @test names(f(nda, dims=:b)) == (:a, :a)
+        # `Statistic.cov(A, dims=p)` for `p > 2` is allowed but returns NaNs. Same for `cor`.
+        @test names(f(nda, dims=3)) == (:_, :_)
+    end
 end

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -181,3 +181,9 @@ end
         @test_throws MethodError f(NamedDimsArray(rand(3, 4, 5), (:a, :b, :c)))
     end
 end
+@testset "cov corrected=$bool" for bool in (true, false)
+    # test that kwargs get passed on correctly
+    A = rand(2, 4)
+    nda = NamedDimsArray{(:a, :b)}(A)
+    @test cov(nda; corrected=bool) == cov(A; corrected=bool)
+end


### PR DESCRIPTION
- closes #41 
- NamedDims still only supports single-arg `cor`/`cov` i.e. for single input `X::AbstractMatrix` (or `x::AbstractVector`, which we get for free)