### PR TITLE
Add function for safely accessing `parent`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 
 For `nda = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))`.
 
- - Unwrapping: `parent(nda)`: returns the underlying `AbstractArray` that is wrapped by the `NamedDimsArray`
- - Indexing: `nda[y=2]`: the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`
- - Functions taking a dims arg: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`
+ - Indexing: `nda[y=2]` is the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`.
+ - Functions taking a `dims` keyword: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`.
  - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
+ - Unwrapping: `parent(nda)` returns the underlying `AbstractArray` that is wrapped by the `NamedDimsArray`.
  - Unnaming: `unname(a)` ensures an `AbstractArray` is _not_ a `NamedDimsArray`;
     if passed a `NamedDimsArray` it unwraps it, otherwise just returns the given `AbstractArray`.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For `nda = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))`.
  - Indexing: `nda[y=2]`: the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`
  - Functions taking a dims arg: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`
  - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
+ - Unnaming: `unname(a)` ensures an `AbstractArray` is _not_ a `NamedDimsArray`;
+    if passed a `NamedDimsArray` it unwraps it, otherwise just returns the given `AbstractArray`.
 
 ### Dimensionally Safe Operations
 

--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -5,7 +5,7 @@ using Base.Broadcast:
 using LinearAlgebra
 using Statistics
 
-export NamedDimsArray, dim, rename
+export NamedDimsArray, dim, rename, unname
 
 # We use CoVector to workout if we are taking the tranpose of a tranpose etc
 const CoVector = Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:AbstractVector}}

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -61,6 +61,17 @@ end
 parent_type(::Type{<:NamedDimsArray{L, T, N, A}}) where {L, T, N, A} = A
 Base.parent(x::NamedDimsArray) = x.data
 
+"""
+    unname(A::NamedDimsArray) -> AbstractArray
+    unname(A::AbstractArray) -> AbstractArray
+
+Return the input array `A` without any dimension names.
+
+For `NamedDimsArray`s this returns the parent array, equivalent to calling `parent`, but for
+any other `AbstractArray` simply returns the input.
+"""
+unname(x::NamedDimsArray) = parent(x)
+unname(x::AbstractArray) = x
 
 """
     names(A)

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -74,16 +74,15 @@ unname(x::NamedDimsArray) = parent(x)
 unname(x::AbstractArray) = x
 
 """
-    names(A)
+    names(A) -> Tuple
 
-Returns a tuple of containing the names of all the dimensions of the array `A`.
+Return the names of all the dimensions of the array `A`.
 """
 names(::Type{<:NamedDimsArray{L}}) where L = L
 names(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
 names(x::T) where T<:AbstractArray = names(T)
 
 dim(a::NamedDimsArray{L}, name) where L = dim(L, name)
-
 
 
 #############################

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -4,10 +4,13 @@ using SparseArrays
 using Test
 
 
-
 @testset "get the parent array that was wrapped" begin
-    orig = [1 2; 3 4]
-    @test parent(NamedDimsArray(orig, (:x, :y))) === orig
+    for orig in ([1 2; 3 4], spzeros(2, 2))
+        @test parent(NamedDimsArray(orig, (:x, :y))) === orig
+
+        @test unname(NamedDimsArray(orig, (:x, :y))) === orig
+        @test unname(orig) === orig
+    end
 end
 
 


### PR DESCRIPTION
- closes #39
- `unname` allow you to ensure you _don't_ have a NamedDimsArray 