### PR TITLE
Change to only increment the patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.0"
+version = "0.2.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
- I forgot that pre v1.0 we can add functionality in patch releases
- #55 bumped the minor version -- this changes that so only the patch version is incremented
- now folks don't have to update compat to get the tiny backward-compatible feature 