### PR TITLE
Stop making Tracker loading depend on version

### DIFF
--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -10,22 +10,8 @@ using Statistics
 export NamedDimsArray, dim, rename, unname
 
 function __init__()
-    @require Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include_tracker_compat()
-end
-
-# For Tracker-NamedDims compatibility we require a Tracker version compatible with 0.2.2.
-# Since we use Requires.jl we have no nicer way to set the Tracker compatability.
-function include_tracker_compat()
-    tracker_version = Pkg.installed()["Tracker"]
-    allowed_versions = Pkg.Types.semver_spec("0.2.2")
-    if tracker_version ∈ allowed_versions
-        include("tracker_compat.jl")
-    else
-        @warn string(
-            "Tracker version not compatible with NamedDims. ",
-            "Tracker compatability functionality has been disabled."
-        ) tracker_version allowed_versions
-    end
+    # NOTE: NamedDims only compatible with Tracker v0.2.2; but no nice way to enforce that.
+    @require Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("tracker_compat.jl")
 end
 
 # We use CoVector to workout if we are taking the tranpose of a tranpose etc

--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -10,7 +10,7 @@ using Statistics
 export NamedDimsArray, dim, rename, unname
 
 function __init__()
-    # NOTE: NamedDims only compatible with Tracker v0.2.2; but no nice way to enforce that.
+    # NOTE: NamedDims is only compatible with Tracker v0.2.2; but no nice way to enforce that.
     @require Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("tracker_compat.jl")
 end
 


### PR DESCRIPTION
- No reliable way to identify the version
- More useful to assume a compatible Tracker
- see https://github.com/invenia/NamedDims.jl/pull/54#discussion_r297233900 (Thanks @KristofferC for noticing this)