### PR TITLE
Add `eachslice` for Julia 1.1+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -48,6 +48,19 @@ for (mod, funs) in (
     end
 end
 
+if VERSION > v"1.1-"
+    function Base.eachslice(a::NamedDimsArray{L}; dims, kwargs...) where L
+        numerical_dims = dim(a, dims)
+        slices = eachslice(parent(a); dims=numerical_dims, kwargs...)
+        return Base.Generator(slices) do slice
+            # For unknown reasons (something to do with hoisting?) having this in the
+            # function passed to `Generator` actually results in less memory being allocated
+            names = remaining_dimnames_after_dropping(L, numerical_dims)
+            return NamedDimsArray(slice, names)
+        end
+    end
+end
+
 # 1 arg before - no default for `dims` keyword
 for (mod, funs) in (
     (:Base, (:mapslices,)),

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -4,8 +4,8 @@ using Test
 using Statistics
 
 @testset "Base" begin
-a = [10 20; 31 40]
-nda = NamedDimsArray(a, (:x, :y))
+    a = [10 20; 31 40]
+    nda = NamedDimsArray(a, (:x, :y))
 
     @testset "$f" for f in (sum, prod, maximum, minimum, extrema)
         @test f(nda) == f(a)
@@ -25,8 +25,8 @@ nda = NamedDimsArray(a, (:x, :y))
     end
 
     @testset "sort!" begin
-        a2 = [1 9; 7 3]
-        nda2 = NamedDimsArray(a2, (:x, :y))
+        a = [1 9; 7 3]
+        nda = NamedDimsArray(a, (:x, :y))
 
         # Vector case
         veca = [1, 9, 7, 3]
@@ -35,28 +35,26 @@ nda = NamedDimsArray(a, (:x, :y))
 
         # Higher-dim case: `dims` keyword in `sort!` requires Julia v1.1+
         if VERSION > v"1.1-"
-            sort!(nda2, dims=:y)
-            @test issorted(a2[2, :])
-            @test_throws UndefKeywordError sort!(nda2)
+            sort!(nda, dims=:y)
+            @test issorted(a[2, :])
+            @test_throws UndefKeywordError sort!(nda)
 
-            sort!(nda2; dims=:x, order=Base.Reverse)
-            @test issorted(a2[:, 1]; order=Base.Reverse)
+            sort!(nda; dims=:x, order=Base.Reverse)
+            @test issorted(a[:, 1]; order=Base.Reverse)
         end
     end
 
     @testset "eachslice" begin
         if VERSION > v"1.1-"
+            slices = [[111 121; 211 221], [112 122; 212 222]]
+            a = cat(slices...; dims=3)
+            nda = NamedDimsArray(a, (:a, :b, :c))
+
             @test (
-                sum(eachslice(nda; dims=:x)) ==
-                sum(eachslice(nda; dims=1)) ==
-                sum(eachslice(a; dims=1)) ==
-                [10 + 31, 20 + 40]
-            )
-            @test (
-                sum(eachslice(nda; dims=:y)) ==
-                sum(eachslice(nda; dims=2)) ==
-                sum(eachslice(a; dims=2)) ==
-                [10 + 20, 31 + 40]
+                sum(eachslice(nda; dims=:c)) ==
+                sum(eachslice(nda; dims=3)) ==
+                sum(eachslice(a; dims=3)) ==
+                slices[1] + slices[2]
             )
             @test_throws ArgumentError eachslice(nda; dims=(1, 2))
             @test_throws ArgumentError eachslice(a; dims=(1, 2))
@@ -65,19 +63,17 @@ nda = NamedDimsArray(a, (:x, :y))
             @test_throws UndefKeywordError eachslice(a)
 
             @test (
-                names(first(eachslice(nda; dims=:y))) ==
+                names(first(eachslice(nda; dims=:b))) ==
                 names(first(eachslice(nda; dims=2))) ==
-                (:x,)
-            )
-            @test (
-                names(first(eachslice(nda; dims=:x))) ==
-                names(first(eachslice(nda; dims=1))) ==
-                (:y,)
+                (:a, :c)
             )
         end
     end
 
     @testset "mapslices" begin
+        a = [10 20; 31 40]
+        nda = NamedDimsArray(a, (:x, :y))
+
         @test (
             mapslices(join, nda; dims=:x) ==
             mapslices(join, nda; dims=1) ==
@@ -104,6 +100,9 @@ nda = NamedDimsArray(a, (:x, :y))
     end
 
     @testset "mapreduce" begin
+        a = [10 20; 31 40]
+        nda = NamedDimsArray(a, (:x, :y))
+
         @test mapreduce(isodd, |, nda) == true == mapreduce(isodd, |, a)
         @test (
             mapreduce(isodd, |, nda; dims=:x) ==
@@ -123,6 +122,9 @@ nda = NamedDimsArray(a, (:x, :y))
     end
 
     @testset "zero" begin
+        a = [10 20; 31 40]
+        nda = NamedDimsArray(a, (:x, :y))
+
         @test zero(nda) == [0 0; 0 0] == zero(a)
         @test names(zero(nda)) == (:x, :y)
     end
@@ -130,6 +132,7 @@ nda = NamedDimsArray(a, (:x, :y))
     @testset "count" begin
         a = [true false; true true]
         nda = NamedDimsArray(a, (:x, :y))
+
         @test count(nda) == count(a) == 3
         @test_throws ErrorException count(nda; dims=:x)
         @test_throws ErrorException count(a; dims=1)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -44,6 +44,39 @@ nda = NamedDimsArray(a, (:x, :y))
         end
     end
 
+    @testset "eachslice" begin
+        if VERSION > v"1.1-"
+            @test (
+                sum(eachslice(nda; dims=:x)) ==
+                sum(eachslice(nda; dims=1)) ==
+                sum(eachslice(a; dims=1)) ==
+                [10 + 31, 20 + 40]
+            )
+            @test (
+                sum(eachslice(nda; dims=:y)) ==
+                sum(eachslice(nda; dims=2)) ==
+                sum(eachslice(a; dims=2)) ==
+                [10 + 20, 31 + 40]
+            )
+            @test_throws ArgumentError eachslice(nda; dims=(1, 2))
+            @test_throws ArgumentError eachslice(a; dims=(1, 2))
+
+            @test_throws UndefKeywordError eachslice(nda)
+            @test_throws UndefKeywordError eachslice(a)
+
+            @test (
+                names(first(eachslice(nda; dims=:y))) ==
+                names(first(eachslice(nda; dims=2))) ==
+                (:x,)
+            )
+            @test (
+                names(first(eachslice(nda; dims=:x))) ==
+                names(first(eachslice(nda; dims=1))) ==
+                (:y,)
+            )
+        end
+    end
+
     @testset "mapslices" begin
         @test (
             mapslices(join, nda; dims=:x) ==


### PR DESCRIPTION
- Partial fix for #34 (1.0 support not added, separate issue now opened for that https://github.com/invenia/NamedDims.jl/issues/59)
- This allocates once more than expected (or maybe twice more, depending on your expectations)
- Joint work with @oxinabox who figured out how to reduce allocations at least this far