### PR TITLE
PermutedDimsArray etc.

### DIFF
--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -57,6 +57,23 @@ for f in (
     end
 end
 
+"""
+    unname(A::NamedDimsArray, names) -> AbstractArray
+
+ Returns the parent array if the given names match those of `A`,
+ otherwise a `transpose` or `PermutedDimsArray` view of the parent data.
+ To ensure a copy, call instead `parent(permutedims(A, names))`.
+"""
+function unname(nda::NamedDimsArray{L,T,N}, names::NTuple{N}) where {L,T,N}
+    perm = dim(nda, names)
+    if perm == ntuple(identity, N)
+        return parent(nda)
+    elseif perm == (2,1)
+        return transpose(parent(nda))
+    else
+        return PermutedDimsArray(parent(nda), perm)
+    end
+end
 
 # reshape
 # For now we only implement the version that drops dimension names

--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -21,8 +21,13 @@ end
 function Base.permutedims(nda::NamedDimsArray{L}, perm) where {L}
     numerical_perm = dim(nda, perm)
     new_names = permute_dimnames(L, numerical_perm)
-
     return NamedDimsArray{new_names}(permutedims(parent(nda), numerical_perm))
+end
+
+function Base.PermutedDimsArray(nda::NamedDimsArray{L}, perm) where {L}
+    numerical_perm = dim(nda, perm)
+    new_names = permute_dimnames(L, numerical_perm)
+    return NamedDimsArray{new_names}(PermutedDimsArray(parent(nda), numerical_perm))
 end
 
 for f in (
@@ -36,7 +41,6 @@ for f in (
         new_names = (:_, first(L))
         return NamedDimsArray{new_names}($f(parent(nda)))
     end
-
 
     # Vector Double Transpose
     if f !== :permutedims

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -55,7 +55,7 @@ end
     end
 end
 
-@testset "permutedims" begin
+@testset "$permutedims" for permutedims in (permutedims, PermutedDimsArray) begin
     nda = NamedDimsArray{(:w, :x, :y, :z)}(ones(10, 20, 30, 40))
     @test (
         names(permutedims(nda, (:w, :x, :y, :z))) ==

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -55,7 +55,7 @@ end
     end
 end
 
-@testset "$permutedims" for permutedims in (permutedims, PermutedDimsArray) begin
+@testset "$permutedims" for permutedims in (permutedims, PermutedDimsArray)
     nda = NamedDimsArray{(:w, :x, :y, :z)}(ones(10, 20, 30, 40))
     @test (
         names(permutedims(nda, (:w, :x, :y, :z))) ==

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -55,48 +55,37 @@ end
     end
 end
 
-@testset "$permutedims" for permutedims in (permutedims, PermutedDimsArray)
+@testset "$f" for f in (permutedims, PermutedDimsArray)
     nda = NamedDimsArray{(:w, :x, :y, :z)}(ones(10, 20, 30, 40))
     @test (
-        names(permutedims(nda, (:w, :x, :y, :z))) ==
-        names(permutedims(nda, 1:4)) ==
+        names(f(nda, (:w, :x, :y, :z))) ==
+        names(f(nda, 1:4)) ==
         (:w, :x, :y, :z)
     )
     @test (
-        size(permutedims(nda, (:w, :x, :y, :z))) ==
-        size(permutedims(nda, 1:4)) ==
+        size(f(nda, (:w, :x, :y, :z))) ==
+        size(f(nda, 1:4)) ==
         (10, 20, 30, 40)
     )
 
     @test (
-        names(permutedims(nda, (:w, :y, :x, :z))) ==
-        names(permutedims(nda, (1, 3, 2, 4))) ==
+        names(f(nda, (:w, :y, :x, :z))) ==
+        names(f(nda, (1, 3, 2, 4))) ==
         (:w, :y, :x, :z)
     )
     @test (
-        size(permutedims(nda, (:w, :y, :x, :z))) ==
-        size(permutedims(nda, (1, 3, 2, 4))) ==
+        size(f(nda, (:w, :y, :x, :z))) ==
+        size(f(nda, (1, 3, 2, 4))) ==
         (10, 30, 20, 40)
     )
 
-    @test_throws Exception permutedims(nda, (:foo,:x,:y,:z))
-    @test_throws Exception permutedims(nda, (:x,:y,:z))
-    @test_throws Exception permutedims(nda, (:x,:x,:y,:z))
+    @test_throws Exception f(nda, (:foo,:x,:y,:z))
+    @test_throws Exception f(nda, (:x,:y,:z))
+    @test_throws Exception f(nda, (:x,:x,:y,:z))
 
-    @test_throws Exception permutedims(nda, (0,1,2,3))
-    @test_throws Exception permutedims(nda, (2,3,4))
-    @test_throws Exception permutedims(nda, (2,2,3,4))
-end
-
-@testset "unname with names" begin
-    nda3 = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))
-    nda2 = NamedDimsArray{(:x, :y)}(rand(10, 20))
-
-    @test unname(nda3, (:x, :y, :z)) === parent(nda3)
-
-    @test unname(nda3, (:z, :y, :x)) === PermutedDimsArray(parent(nda3), (3,2,1))
-
-    @test unname(nda2, (:y, :x)) === transpose(parent(nda2))
+    @test_throws Exception f(nda, (0,1,2,3))
+    @test_throws Exception f(nda, (2,3,4))
+    @test_throws Exception f(nda, (2,2,3,4))
 end
 
 # We test pinv here as it is defined in src/function_dims.jl

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -88,6 +88,17 @@ end
     @test_throws Exception permutedims(nda, (2,2,3,4))
 end
 
+@testset "unname with names" begin
+    nda3 = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))
+    nda2 = NamedDimsArray{(:x, :y)}(rand(10, 20))
+
+    @test unname(nda3, (:x, :y, :z)) === parent(nda3)
+
+    @test unname(nda3, (:z, :y, :x)) === PermutedDimsArray(parent(nda3), (3,2,1))
+
+    @test unname(nda2, (:y, :x)) === transpose(parent(nda2))
+end
+
 # We test pinv here as it is defined in src/function_dims.jl
 # using the same logic as permutedims, transpose etc
 @testset "pinv" begin


### PR DESCRIPTION
This treats `PermutedDimsArray` exactly like `permutedims`. 

And it adds a method `unname(A::NamedDimsArray, names)` which is always a view of the parent, with axes ordered to match the given names. 