### PR TITLE
eachslice + collect

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -101,7 +101,7 @@ end
 ################################################
 # Generators
 
-if VERSION > v"1.1-"
+@static if VERSION >= v"1.1"
     Base.eachslice(A::NamedDimsArray; dims) = _eachslice(A, dims)
 else
     eachcol(A::AbstractVecOrMat) = (view(A, :, i) for i in axes(A, 2))

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -45,7 +45,9 @@ using Statistics
     end
 
     @testset "eachslice" begin
-        if VERSION > v"1.1-"
+        if VERSION < v"1.1-"
+            using NamedDims: eachslice
+        end
             slices = [[111 121; 211 221], [112 122; 212 222]]
             a = cat(slices...; dims=3)
             nda = NamedDimsArray(a, (:a, :b, :c))
@@ -67,7 +69,29 @@ using Statistics
                 names(first(eachslice(nda; dims=2))) ==
                 (:a, :c)
             )
+    end
+
+    @testset "eachcol, eachrow" begin
+        if VERSION < v"1.1-"
+            using NamedDims: eachrow, eachcol
         end
+        nda = NamedDimsArray([10 20; 31 40], (:x, :y))
+
+        @test names(first(eachcol(nda))) == (:x,)
+        @test names(first(eachrow(nda))) == (:y,)
+
+        @test_broken names(collect(eachcol(nda))) == (:y,)
+        @test_broken names(collect(eachrow(nda))) == (:y,)
+    end
+
+    @testset "collect" begin
+        ndv = NamedDimsArray([1, 9, 7, 3], :vec)
+        @test names([sqrt(x) for x in ndv]) == (:vec,)
+
+        nda = NamedDimsArray([10 20; 31 40], (:x, :y))
+        @test names([x^2 for x in nda]) == (:x, :y)
+
+        @test_broken names([x^2 + y for x in nda, y in ndv]) == (:x, :y, :vec)
     end
 
     @testset "mapslices" begin

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -79,9 +79,6 @@ using Statistics
 
         @test names(first(eachcol(nda))) == (:x,)
         @test names(first(eachrow(nda))) == (:y,)
-
-        @test_broken names(collect(eachcol(nda))) == (:y,)
-        @test_broken names(collect(eachrow(nda))) == (:y,)
     end
 
     @testset "collect" begin
@@ -90,8 +87,6 @@ using Statistics
 
         nda = NamedDimsArray([10 20; 31 40], (:x, :y))
         @test names([x^2 for x in nda]) == (:x, :y)
-
-        @test_broken names([x^2 + y for x in nda, y in ndv]) == (:x, :y, :vec)
     end
 
     @testset "mapslices" begin


### PR DESCRIPTION
I believe this closes #59 and #34.

I ‘m not sure why write a custom generator for `eachslice`. This PR changes it to just looks up `dims`, then run the same code as base:
```julia
julia> ab = NamedDimsArray((1:3) .+ zeros(Int,3)', (:a, :b));

julia> @btime eachslice($ab, dims=:b); # master: 319.215 ns (5 allocations: 112 bytes)
  220.690 ns (3 allocations: 64 bytes) 

julia> @btime eachslice($(parent(ab)), dims=2);
  216.897 ns (3 allocations: 64 bytes)

julia> @btime [sum(x)^2 for x in eachslice($ab, dims=:b)]; # master: 14.636 μs (40 allocations: 1.73 KiB)
  383.851 ns (8 allocations: 336 bytes)
```
Still much slower than `eachcol`, for which there is no special code at all:
```julia
julia> NamedDims.names(first(eachcol(ab)))
(:a,)

julia> @btime eachcol($ab);
  12.992 ns (2 allocations: 48 bytes)

julia> @btime [sum(x)^2 for x in eachcol($ab)];
  76.208 ns (7 allocations: 320 bytes)
```

It also adds the simplest possible overload of `collect` so that simple comprehensions will keep names. Doesn’t work on generators of generators, nor products:
```julia
julia> [x^2 for x in ab]
3×3 NamedDimsArray{(:a, :b),Int64,2,Array{Int64,2}}:
 1  1  1
 4  4  4
 9  9  9

julia> NamedDims.names([sum(x)^2 for x in eachcol(ab)]) # doesn't work yet
(:_,)
```