### PR TITLE
Allocation tests from comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -118,8 +118,9 @@ Returns the values of the `named_inds`, sorted as per the order they appear in `
 with any missing dimnames, having there value set to `:`.
 An error is thrown if any dimnames are given in `named_inds` that do not occur in `dimnames`.
 """
-function order_named_inds(dimnames::Tuple{Vararg{Symbol,N}}; named_inds...) where {N}
-    # 0-Allocations: see `@code_typed (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()`
+order_named_inds(dimnames::Tuple; named_inds...) = order_named_inds(dimnames, named_inds.data)
+
+function order_named_inds(dimnames::Tuple{Vararg{Symbol,N}}, named_inds::NamedTuple) where {N}
     if !tuple_issubset(keys(named_inds), dimnames)
         throw(DimensionMismatch("Expected subset of $(dimnames), got $(keys(named_inds))"))
     end

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -3,6 +3,7 @@ using NamedDims
 using NamedDims: matrix_prod_names, names, symmetric_names
 using Test
 
+
 @testset "+" begin
     nda = NamedDimsArray{(:a,)}(ones(3))
 
@@ -100,8 +101,6 @@ end
         @test matrix_prod_names((:foo, :_), (:bar,)) == (:foo,)
         @test matrix_prod_names((:foo, :_), (:_,)) == (:foo,)
         @test_throws DimensionMismatch matrix_prod_names((:foo, :bar), (:nope,))
-
-        @test 0 == @allocated (() -> matrix_prod_names((:foo, :bar), (:bar,)))()
     end
 
     @testset "Matrix-Matrix" begin
@@ -153,6 +152,11 @@ end
         @test_throws DimensionMismatch ndv' * ndv2
     end
 end
+@testset "allocations: matmul names" begin
+    @test 0 == @allocated (() -> matrix_prod_names((:foo, :bar), (:bar,)))()
+    @test 0 == @allocated (() -> symmetric_names((:foo, :bar), 1))()
+end
+
 
 @testset "Mutmul with special types" begin
     nda = NamedDimsArray{(:a, :b)}(ones(5,5))
@@ -163,12 +167,14 @@ end
     end
 end
 
+
 @testset "inv" begin
     nda = NamedDimsArray{(:a, :b)}([1.0 2; 3 4])
     @test names(inv(nda)) == (:b, :a)
     @test nda * inv(nda) ≈ NamedDimsArray{(:a, :a)}([1.0 0; 0 1])
     @test inv(nda) * nda ≈ NamedDimsArray{(:b, :b)}([1.0 0; 0 1])
 end
+
 
 @testset "cov/cor" begin
     @testset "symmetric_names" begin
@@ -177,8 +183,6 @@ end
         @test symmetric_names((:a, :b), 5) == (:_, :_)
 
         @test_throws MethodError symmetric_names((:a, :b, :c), 2)
-
-        @test 0 == @allocated (() -> symmetric_names((:foo, :bar), 1))()
     end
     @testset "$f" for f in (cov, cor)
         @testset "matrix input, matrix result" begin

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -100,6 +100,8 @@ end
         @test matrix_prod_names((:foo, :_), (:bar,)) == (:foo,)
         @test matrix_prod_names((:foo, :_), (:_,)) == (:foo,)
         @test_throws DimensionMismatch matrix_prod_names((:foo, :bar), (:nope,))
+
+        @test 0 == @allocated (() -> matrix_prod_names((:foo, :bar), (:bar,)))()
     end
 
     @testset "Matrix-Matrix" begin
@@ -173,7 +175,10 @@ end
         @test symmetric_names((:a, :b), 1) == (:b, :b)
         @test symmetric_names((:a, :b), 2) == (:a, :a)
         @test symmetric_names((:a, :b), 5) == (:_, :_)
+
         @test_throws MethodError symmetric_names((:a, :b, :c), 2)
+
+        @test 0 == @allocated (() -> symmetric_names((:foo, :bar), 1))()
     end
     @testset "$f" for f in (cov, cor)
         @testset "matrix input, matrix result" begin

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -29,6 +29,8 @@ using Test
     @test 0 == @allocated (()->dim_noerror((:a, :b, :c), :c))()
     if VERSION >= v"1.1"
         @test 0 == @allocated (()->dim((:a,:b), (:a,:b)))()
+    else
+        @test_broken 0 == @allocated (()->dim((:a,:b), (:a,:b)))()
     end
 end
 
@@ -68,6 +70,9 @@ end
     if VERSION >= v"1.1"
         @test 0 == @allocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
         @test 0 == @allocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
+    else
+        @test_broken 0 == @allocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
+        @test_broken 0 == @allocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
     end
 end
 
@@ -82,12 +87,10 @@ end
     @test order_named_inds((:x, :y); x=30, y=20) == (30, 20)
 
     @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))() # from code comment
-    if VERSION != v"1.1"
-        @info "on version 1.1 this should NOT run" VERSION
-        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
-    else
-        @info "on version 1.1 this should run" VERSION
+    if v"1.1-" <= VERSION <= v"1.1.99" # test passes on 1.1, but travis has 1.1.1
         @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
+    else
+        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
     end
 end
 

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -25,6 +25,8 @@ using Test
         @test dim((:x, :y, :a, :b, :c, :d), :d) == 6
         @test_throws ArgumentError dim((:x, :y, :a, :b, :c, :d), :z) # not found
     end
+end
+@testset "allocations: dim" begin
     @test 0 == @allocated (()->dim((:a, :b), :b))()
     @test 0 == @allocated (()->dim_noerror((:a, :b, :c), :c))()
     if VERSION >= v"1.1"
@@ -34,7 +36,8 @@ using Test
     end
 end
 
- @testset "unify_names_*" begin
+
+@testset "unify_names_*" begin
     @test_throws DimensionMismatch unify_names((:a,), (:a, :b,))
 
     @test unify_names_longest((:a,), (:a, :b,)) == (:a, :b)
@@ -60,7 +63,10 @@ end
         @test_throws DimensionMismatch unify((:a,), (:b,))
         @test_throws DimensionMismatch unify((:a,:b), (:b, :a))
         @test_throws DimensionMismatch unify((:a, :b, :c), (:_, :_, :d))
-
+    end
+end
+@testset "allocations: unify_names_*" begin
+    for unify in (unify_names, unify_names_longest, unify_names_shortest)
         if VERSION >= v"1.2"
             @test 0 == @allocated (()->unify((:a, :b), (:a, :_)))()
         else
@@ -76,6 +82,7 @@ end
     end
 end
 
+
 @testset "order_named_inds" begin
     @test order_named_inds((:x,)) == (:,)
     @test order_named_inds((:x,); x=2) == (2,)
@@ -85,8 +92,9 @@ end
     @test order_named_inds((:x, :y); y=2, ) == (:, 2)
     @test order_named_inds((:x, :y); y=20, x=30) == (30, 20)
     @test order_named_inds((:x, :y); x=30, y=20) == (30, 20)
-
-    if v"1.1-" <= VERSION <= v"1.2-" # test passes on 1.1, but travis has 1.1.1
+end
+@testset "allocations: order_named_inds" begin
+    if v"1.1-" <= VERSION <= v"1.2-" # test passes on 1.1, including 1.1.1
         @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
         @test 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
     else
@@ -94,6 +102,7 @@ end
         @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
     end
 end
+
 
 @testset "remaining_dimnames_from_indexing" begin
     @test remaining_dimnames_from_indexing((:a, :b, :c), (10,20,30)) == tuple()
@@ -103,19 +112,23 @@ end
     @test remaining_dimnames_from_indexing((:a, :b, :c), (:, [CartesianIndex()], :, :)) == (:a, :_, :b, :c)
     @test remaining_dimnames_from_indexing((:a, :b, :c), (1, [CartesianIndex()], 2, :)) == (:_, :c)
     @test remaining_dimnames_from_indexing((:a, :b, :c), (CartesianIndex(1,1), :)) == (:c,)
-
+end
+@testset "allocations: remaining_dimnames_from_indexing" begin
     @test 0 == @allocated (()->remaining_dimnames_from_indexing((:a, :b, :c), (:,390,:)))()
 end
+
 
 @testset "remaining_dimnames_after_dropping" begin
     @test remaining_dimnames_after_dropping((:a, :b, :c), 1) == (:b, :c)
     @test remaining_dimnames_after_dropping((:a, :b, :c), 3) == (:a, :b)
     @test remaining_dimnames_after_dropping((:a, :b, :c), (1,3)) == (:b,)
     @test remaining_dimnames_after_dropping((:a, :b, :c), (3,1)) == (:b,)
-
+end
+@testset "allocations: remaining_dimnames_after_dropping" begin
     @test 0 == @allocated remaining_dimnames_after_dropping((:a,:b,:c,:d,:e), 4)
     @test 0 == @allocated (()->remaining_dimnames_after_dropping((:a,:b,:c,:d,:e), (1,3)))()
 end
+
 
 @testset "permute_dimnames" begin
     @test permute_dimnames((:a, :b, :c), (1, 2, 3)) == (:a ,:b, :c)
@@ -127,16 +140,19 @@ end
 
     @test_throws BoundsError permute_dimnames((:a, :b, :c), (30, 30, 30))
     @test_throws BoundsError permute_dimnames((:a, :b), (1, 0))
-
+end
+@testset "allocations: permute_dimnames" begin
     if VERSION >= v"1.1"
         @test 0 == @allocated permute_dimnames((:a,:b,:c), (1,3,2))
     end
 end
 
+
 @testset "tuple_issubset" begin
     @test tuple_issubset((:a, :c), (:a, :b, :c)) == true
     @test tuple_issubset((:a, :b, :c), (:a, :c)) == false
-
+end
+@testset "allocations: tuple_issubset" begin
     @test 0 == @allocated tuple_issubset((:a, :c), (:a, :b, :c))
     @test 0 == @allocated tuple_issubset((:a, :b, :c), (:a, :c))
 end

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -86,11 +86,12 @@ end
     @test order_named_inds((:x, :y); y=20, x=30) == (30, 20)
     @test order_named_inds((:x, :y); x=30, y=20) == (30, 20)
 
-    @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))() # from code comment
-    if v"1.1-" <= VERSION <= v"1.1.99" # test passes on 1.1, but travis has 1.1.1
+    if v"1.1-" <= VERSION <= v"1.2-" # test passes on 1.1, but travis has 1.1.1
         @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
+        @test 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
     else
-        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
+        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
+        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
     end
 end
 

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -83,8 +83,10 @@ end
 
     @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))() # from code comment
     if VERSION != v"1.1"
+        @info "on version 1.1 this should NOT run" VERSION
         @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
     else
+        @info "on version 1.1 this should run" VERSION
         @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
     end
 end

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -26,8 +26,10 @@ using Test
         @test_throws ArgumentError dim((:x, :y, :a, :b, :c, :d), :z) # not found
     end
     @test 0 == @allocated (()->dim((:a, :b), :b))()
-    @test 0 == @allocated (()->dim((:a,:b), (:a,:b)))()
     @test 0 == @allocated (()->dim_noerror((:a, :b, :c), :c))()
+    if VERSION >= v"1.1"
+        @test 0 == @allocated (()->dim((:a,:b), (:a,:b)))()
+    end
 end
 
  @testset "unify_names_*" begin
@@ -57,10 +59,16 @@ end
         @test_throws DimensionMismatch unify((:a,:b), (:b, :a))
         @test_throws DimensionMismatch unify((:a, :b, :c), (:_, :_, :d))
 
-        @test 0 == @allocated (()->unify((:a, :b), (:a, :_)))()
+        if VERSION >= v"1.2"
+            @test 0 == @allocated (()->unify((:a, :b), (:a, :_)))()
+        else
+            @test_broken 0 == @allocated (()->unify((:a, :b), (:a, :_)))()
+        end
     end
-    @test 0 == @allocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
-    @test 0 == @allocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
+    if VERSION >= v"1.1"
+        @test 0 == @allocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
+        @test 0 == @allocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
+    end
 end
 
 @testset "order_named_inds" begin
@@ -74,7 +82,11 @@ end
     @test order_named_inds((:x, :y); x=30, y=20) == (30, 20)
 
     @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))() # from code comment
-    @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
+    if VERSION != v"1.1"
+        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))() # test as used now
+    else
+        @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
+    end
 end
 
 @testset "remaining_dimnames_from_indexing" begin
@@ -110,7 +122,9 @@ end
     @test_throws BoundsError permute_dimnames((:a, :b, :c), (30, 30, 30))
     @test_throws BoundsError permute_dimnames((:a, :b), (1, 0))
 
-    @test 0 == @allocated permute_dimnames((:a,:b,:c), (1,3,2))
+    if VERSION >= v"1.1"
+        @test 0 == @allocated permute_dimnames((:a,:b,:c), (1,3,2))
+    end
 end
 
 @testset "tuple_issubset" begin


### PR DESCRIPTION
This copies all the `@btime` comments in source to be real tests. 

Motivated by noticing that the one for `order_named_inds` fails on Julia 1.2, which leads to slow indexing:
```
data = rand(2,3);
nda = NamedDimsArray(data, (:row, :col))

@btime $data[2,3]
@btime $nda[2,3]  # good, 1 ns
@btime $nda[row=2, col=3] # bad, 200 ns (or 50 ns on 1.1)
```
I have a partial fix (50ns, but still nonzero allocations) which I'll add if you don't object, just two lines.