### PR TITLE
names(permutedims(transpose(ndv)))

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -17,7 +17,6 @@ function Base.dropdims(nda::NamedDimsArray; dims)
     return NamedDimsArray{L}(data)
 end
 
-
 function Base.permutedims(nda::NamedDimsArray{L}, perm) where {L}
     numerical_perm = dim(nda, perm)
     new_names = permute_dimnames(L, numerical_perm)
@@ -41,9 +40,8 @@ for f in (
         return NamedDimsArray{new_names}($f(parent(nda)))
     end
 
-
     # Vector Double Transpose
-    if f !== :permutedims
+    if f != :(Base.permutedims)
         @eval function $f(nda::NamedDimsArray{L,T,2,A}) where {L,T,A<:CoVector}
             new_names = (last(L),)  # drop the name of the first dimensions
             return NamedDimsArray{new_names}($f(parent(nda)))

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -66,6 +66,11 @@ end
 end
 
 @testset "permutedims" begin
+    ndv = NamedDimsArray([10, 20, 30], :foo)
+    # mixed case missing from above $f tests:
+    @test size(permutedims(adjoint(ndv))) == (3, 1)
+    @test names(permutedims(transpose(ndv))) == (:foo, :_)
+
     nda = NamedDimsArray{(:w, :x, :y, :z)}(ones(10, 20, 30, 40))
     @test (
         names(permutedims(nda, (:w, :x, :y, :z))) ==


### PR DESCRIPTION
Minimal fix of a bug that crept in.

Maximal fix is this:
```
    @eval function $f(nda::NamedDimsArray{L}) where (L)
        data = $f(parent(nda))
        new_names = if ndims(nda) == 1 # vector input
            (:_, first(L))
        elseif ndims(data) == 1 # vector output
            (last(L),)
        else
            (last(L), first(L))
        end
        return NamedDimsArray(data, new_names)
    end
```