### PR TITLE
parent(x) = getfield(x, :data)

### DIFF
--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -58,7 +58,7 @@ end
 
 parent_type(::Type{<:NamedDimsArray{L, T, N, A}}) where {L, T, N, A} = A
 
-Base.parent(x::NamedDimsArray) = x.data
+Base.parent(x::NamedDimsArray) = getfield(x, :data)
 
 """
     unname(A::NamedDimsArray) -> AbstractArray


### PR DESCRIPTION
This caused performance problems when defining `getproperty(::NamedDimsArray{L,T,N,::MyType}, s)`. 