### PR TITLE
reshape simple case

### DIFF
--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -58,4 +58,4 @@ end
 
 # reshape
 # For now we only implement the version that drops dimension names
-Base.reshape(nda::NamedDimsArray, dims::Int...) = reshape(parent(nda), dims...)
+Base.reshape(x::NamedDimsArray, d::Vararg{Union{Colon, Int}}) = reshape(parent(x), d)

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -22,6 +22,16 @@ end
 
     @test dropdims(nda; dims=(:b,:c)) == ones(10, 20) == dropdims(nda; dims=(2, 3))
     @test names(dropdims(nda; dims=(:b, :c))) == (:a, :d) == names(dropdims(nda; dims=(2, 3)))
+
+end
+
+@testset "reshape" begin
+    nda = NamedDimsArray(rand(2, 3), (:r, :c))
+
+    @test reshape(nda, 3, 2) isa Array
+    @test reshape(nda, 1, :) isa Array
+    @test reshape(nda, :) isa Array
+    @test vec(nda) isa Array
 end
 
 @testset "selectdim" begin


### PR DESCRIPTION
This is a tiny fix of `reshape` to do what I think you intended, and avoid this:
```
nda = NamedDimsArray(rand(2, 3), (:r, :c))
reshape(nda, 1, :) # 1×6 reshape(::NamedDimsArray{(:r, :c), …
```