### PR TITLE
Make keyword indexing fast

### DIFF
--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -17,8 +17,8 @@ end
 # We use CoVector to workout if we are taking the tranpose of a tranpose etc
 const CoVector = Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:AbstractVector}}
 
-include("wrapper_array.jl")
 include("name_core.jl")
+include("wrapper_array.jl")
 include("broadcasting.jl")
 include("functions.jl")
 include("functions_dims.jl")

--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -17,8 +17,8 @@ end
 # We use CoVector to workout if we are taking the tranpose of a tranpose etc
 const CoVector = Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:AbstractVector}}
 
-include("name_core.jl")
 include("wrapper_array.jl")
+include("name_core.jl")
 include("broadcasting.jl")
 include("functions.jl")
 include("functions_dims.jl")

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -111,17 +111,18 @@ Base.@pure function tuple_issubset(lhs::Tuple{Vararg{Symbol,N}}, rhs::Tuple{Vara
     return true
 end
 
-"""
-    order_named_inds(nda; kw...)
-    order_named_inds(nda, namedtuple)
 
-Returns the tuple of index values for `nda`, when indexed by keywords.
+"""
+    order_named_inds(Val(names); kw...)
+    order_named_inds(Val(names), namedtuple)
+
+Returns the tuple of index values for an array with `names`, when indexed by keywords.
 Any dimensions not fixed are given as `:`, to make a slice.
 An error is thrown if any keywords are used which do not occur in `nda`'s names.
 """
-order_named_inds(nda::NamedDimsArray; kw...) = order_named_inds(nda, kw.data)
+order_named_inds(val::Val{L}; kw...) where {L} = order_named_inds(val, kw.data)
 
-@generated function order_named_inds(nda::NamedDimsArray{L}, ni::NamedTuple{K}) where {L,K}
+@generated function order_named_inds(val::Val{L}, ni::NamedTuple{K}) where {L,K}
     tuple_issubset(K, L) || throw(DimensionMismatch("Expected subset of $L, got $K"))
     exs = map(L) do n
         if Base.sym_in(n, K)

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -135,6 +135,30 @@ function Base.similar(
     return similar(a, eltype, dims)
 end
 
+###############################
+# kwargs indexing
+
+"""
+    order_named_inds(A; named_inds...)
+
+Returns the indices that have the names and values given by `named_inds`
+sorted into the order expected for the dimension of the array `A`.
+If any dimensions of `A` are not present in the named_inds,
+then they are given the value `:`, for slicing
+
+For example:
+```
+A = NamedDimArray(rand(4,4), (:x,, :y))
+order_named_inds(A; y=10, x=13) == (13,10)
+order_named_inds(A; x=2, y=1:3) == (2, 1:3)
+order_named_inds(A; y=5) == (:, 5)
+```
+
+This provides the core indexed lookup for `getindex` and `setindex` on the Array `A`
+"""
+function order_named_inds(A::NamedDimsArray{L}; named_inds...) where {L}
+    return order_named_inds(Val{L}(); named_inds...)
+end
 
 ###################
 # getindex / view / dotview

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -136,29 +136,6 @@ function Base.similar(
 end
 
 
-###############################
-# kwargs indexing
-
-"""
-    order_named_inds(A, named_inds...)
-
-Returns the indices that have the names and values given by `named_inds`
-sorted into the order expected for the dimension of the array `A`.
-If any dimensions of `A` are not present in the named_inds,
-then they are given the value `:`, for slicing
-
-For example:
-```
-A = NamedDimArray(rand(4,4), (:x,, :y))
-order_named_inds(A; y=10, x=13) == (13,10)
-order_named_inds(A; x=2, y=1:3) == (2, 1:3)
-order_named_inds(A; y=5) == (:, 5)
-```
-
-This provides the core indexed lookup for `getindex` and `setindex` on the Array `A`
-"""
-order_named_inds(A::AbstractArray; named_inds...) = order_named_inds(dimnames(A); named_inds...)
-
 ###################
 # getindex / view / dotview
 # Note that `dotview` is undocumented but needed for making `a[x=2] .= 3` work

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -93,21 +93,18 @@ end
 
 
 @testset "order_named_inds" begin
-    ndx = NamedDimsArray(ones(2), :x)
-    @test order_named_inds(ndx) == (:,)
-    @test order_named_inds(ndx; x=2) == (2,)
+    @test order_named_inds(Val((:x,))) == (:,)
+    @test order_named_inds(Val((:x,)); x=2) == (2,)
 
-    ndxy = NamedDimsArray(ones(2,2), (:x, :y))
-    @test order_named_inds(ndxy) == (:, :)
-    @test order_named_inds(ndxy; x=2) == (2, :)
-    @test order_named_inds(ndxy; y=2, ) == (:, 2)
-    @test order_named_inds(ndxy; y=20, x=30) == (30, 20)
-    @test order_named_inds(ndxy; x=30, y=20) == (30, 20)
+    @test order_named_inds(Val((:x, :y))) == (:, :)
+    @test order_named_inds(Val((:x, :y)); x=2) == (2, :)
+    @test order_named_inds(Val((:x, :y)); y=2, ) == (:, 2)
+    @test order_named_inds(Val((:x, :y)); y=20, x=30) == (30, 20)
+    @test order_named_inds(Val((:x, :y)); x=30, y=20) == (30, 20)
 end
 @testset "allocations: order_named_inds" begin
-    ndabc = NamedDimsArray(ones(2,2,2), (:a, :b, :c))
-    @test 0 == @allocated (()->order_named_inds(ndabc; b=1, c=2))()
-    @test 0 == @allocated (()->order_named_inds(ndabc, (b=1, c=2)))()
+    @test 0 == @allocated (()->order_named_inds(Val((:a, :b, :c)); b=1, c=2))()
+    @test 0 == @allocated (()->order_named_inds(Val((:a, :b, :c)), (b=1, c=2)))()
 end
 
 

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -93,23 +93,21 @@ end
 
 
 @testset "order_named_inds" begin
-    @test order_named_inds((:x,)) == (:,)
-    @test order_named_inds((:x,); x=2) == (2,)
+    ndx = NamedDimsArray(ones(2), :x)
+    @test order_named_inds(ndx) == (:,)
+    @test order_named_inds(ndx; x=2) == (2,)
 
-    @test order_named_inds((:x, :y,)) == (:, :)
-    @test order_named_inds((:x, :y); x=2) == (2, :)
-    @test order_named_inds((:x, :y); y=2, ) == (:, 2)
-    @test order_named_inds((:x, :y); y=20, x=30) == (30, 20)
-    @test order_named_inds((:x, :y); x=30, y=20) == (30, 20)
+    ndxy = NamedDimsArray(ones(2,2), (:x, :y))
+    @test order_named_inds(ndxy) == (:, :)
+    @test order_named_inds(ndxy; x=2) == (2, :)
+    @test order_named_inds(ndxy; y=2, ) == (:, 2)
+    @test order_named_inds(ndxy; y=20, x=30) == (30, 20)
+    @test order_named_inds(ndxy; x=30, y=20) == (30, 20)
 end
 @testset "allocations: order_named_inds" begin
-    if v"1.1-" <= VERSION <= v"1.2-" # test passes on 1.1, including 1.1.1
-        @test 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
-        @test 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
-    else
-        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c); b=1, c=2))()
-        @test_broken 0 == @allocated (()->order_named_inds((:a, :b, :c), (b=1, c=2)))()
-    end
+    ndabc = NamedDimsArray(ones(2,2,2), (:a, :b, :c))
+    @test 0 == @allocated (()->order_named_inds(ndabc; b=1, c=2))()
+    @test 0 == @allocated (()->order_named_inds(ndabc, (b=1, c=2)))()
 end
 
 

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -185,13 +185,8 @@ const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
     # indexing
     @test 0 == @allocated cnda[1,1]
     @test 0 == @allocated cnda[1,1] = 55
-    if v"1.1-" <= VERSION <= v"1.2-" # tests pass on 1.1, including 1.1.1
-        @test 0 == @allocated cnda[x=1,y=1]
-        @test @allocated(cnda[x=1]) == @allocated(cnda[1,:])
-        @test 0 == @allocated cnda[x=1,y=1] = 66
-    else
-        @test_broken 0 == @allocated cnda[x=1,y=1]
-        @test_broken @allocated(cnda[x=1]) == @allocated(cnda[1,:])
-        @test_broken 0 == @allocated cnda[x=1,y=1] = 66
-    end
+
+    @test 0 == @allocated cnda[x=1, y=1]
+    @test @allocated(cnda[x=1]) == @allocated(cnda[1, :])
+    @test 0 == @allocated cnda[x=1, y=1] = 66
 end


### PR DESCRIPTION
This solves the `order_named_inds` problem by just making it generated, I fiddled around but couldn’t make other ways work. Not sure whether the body should then live in src/name_core.jl (as now) or move to src/wrapper_array.jl (where the function of this signature used to live).

Before:
```
julia> nda = NamedDimsArray(rand(2,2), (:x, :y));

julia> @btime $nda[1, 2];
  1.421 ns (0 allocations: 0 bytes)

julia> @btime $nda[x=1, y=2];
  40.455 ns (2 allocations: 64 bytes)
```
After:
```
julia> @btime $nda[x=1, y=2]
  1.420 ns (0 allocations: 0 bytes)
```

Edit: Note that this was the original motivation for #76. Which included a partial fix to get this down from 200ns. 