### PR TITLE
Fix #90

### DIFF
--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -44,10 +44,8 @@ function NamedDimsArray{L}(orig::AbstractArray{T, N}) where {L, T, N}
     return NamedDimsArray{L, T, N, typeof(orig)}(orig)
 end
 
-function NamedDimsArray(orig::AbstractArray{T, N}, names::NTuple{N, Symbol}) where {T, N}
-    return NamedDimsArray{names}(orig)
-end
-NamedDimsArray(orig::AbstractVector, name::Symbol) = NamedDimsArray(orig, (name,))
+@inline NamedDimsArray(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
+@inline NamedDimsArray(orig::AbstractVector, name::Symbol) = NamedDimsArray(orig, (name,))
 
 # Name-asserting constructor (like renaming, but only for wildcards (`:_`).)
 NamedDimsArray{L}(orig::NamedDimsArray{L}) where L = orig


### PR DESCRIPTION
Before: 
```julia
julia> X = randn(500, 30);

julia> Y = NamedDimsArray(X, (:N, :D));

julia> @btime NamedDimsArray($X, (:N, :D)); # first construction also slow
  515.563 ns (6 allocations: 272 bytes)

julia> @btime NamedDimsArray{(:N, :D)}($X);
  5.691 ns (1 allocation: 16 bytes)

julia> @btime NamedDimsArray($Y, (:N, :D)); # as in issue 90
  511.484 ns (5 allocations: 256 bytes)

julia> @btime NamedDimsArray{(:N, :D)}($Y);
  1.421 ns (0 allocations: 0 bytes)

julia> const cnda = NamedDimsArray([10 20; 30 40], (:x, :y)); # from allocation tests

julia> 0 == @allocated NamedDimsArray(cnda, (:x, :y))
true

julia> NamedDimsArray(Y, (:N, :D));

julia> @allocated NamedDimsArray(Y, (:N, :D)) # without const
256

julia> @allocated (() -> NamedDimsArray(Y, (:N, :D)))()
256
```
Afterwards, these are all fast. 

The allocation test [from the tests](https://github.com/invenia/NamedDims.jl/blob/master/test/wrapper_array.jl#L178) is still happy, and the one without `const` is the same. 

But `@btime` we can trust, right? Then it closes #90. 