### PR TITLE
Replace name asserting constructor with refine names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For `nda = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))`.
 
  - Indexing: `nda[y=2]` is the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`.
  - Functions taking a `dims` keyword: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`.
- - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data
+ - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
  - Unwrapping: `parent(nda)` returns the underlying `AbstractArray` that is wrapped by the `NamedDimsArray`.
  - Unnaming: `unname(a)` ensures an `AbstractArray` is _not_ a `NamedDimsArray`;
     if passed a `NamedDimsArray` it unwraps it, otherwise just returns the given `AbstractArray`.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ For `nda = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))`.
 
  - Indexing: `nda[y=2]` is the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`.
  - Functions taking a `dims` keyword: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`.
- - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
+ - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data
  - Unwrapping: `parent(nda)` returns the underlying `AbstractArray` that is wrapped by the `NamedDimsArray`.
  - Unnaming: `unname(a)` ensures an `AbstractArray` is _not_ a `NamedDimsArray`;
     if passed a `NamedDimsArray` it unwraps it, otherwise just returns the given `AbstractArray`.
+ - Refining Names: `refine_names(nda, names)` returns a new `NamedDimsArray` with any unnamed dimensions of `nda` getting their names from `names`. It errors if any names present in both disagree.
 
 ### Dimensionally Safe Operations
 
@@ -36,8 +37,7 @@ You can use this to bypass the protection,
 
 ### Partially Named Dimensions (`:_`)
 
-To allow for arrays where only some dimensions have names,
-the name `:_` is treated as a wildcard.
+To allow for arrays where only some dimensions have names, the name `:_` is treated as a wildcard.
 Dimensions named with `:_` will not be protected against operating between dimensions of different names; in these cases the result will take the name from the non-wildcard name, if any of the operands had such a concrete name.
 For example:
 `NamedDimsArray{(:time,:_)}(ones(5,2)) + NamedDimsArray{(:_, :place,)}(ones(5,2))`
@@ -59,13 +59,15 @@ whether they are using `NamedDimsArray`s or not.
 While also being able to use `NamedDimsArray`s internally in its definition;
 and also getting the assertion when a `NamedDimsArray` _is_  passed in, that it has the
 expected dimensions.
-The way to do this is to call the `NamedDimsArray` constructor, with the expected names
-within the function.
+The way to do this is to use the `refine_names(x, expected_names)`.
+This will: apply the names to a unnamed array, or to unnamed dimensions in a `NamedDimsArray,
+while also asserting any names that were given are correct.
+
 As in the following example:
 
 ```
 function total_variance(data::AbstractMatrix)
-    n_data = NamedDimsArray(data, (:times, :locations))
+    n_data = refine_names(data, (:times, :locations))
     location_variance = var(n_data; dims=:times)  # calculate variance at each location
     return sum(location_variance; dims=:locations)  # total them
 end

--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -7,7 +7,7 @@ using Pkg
 using Requires
 using Statistics
 
-export NamedDimsArray, dim, rename, unname, dimnames
+export NamedDimsArray, dim, refine_names, rename, unname, dimnames
 
 function __init__()
     # NOTE: NamedDims is only compatible with Tracker v0.2.2; but no nice way to enforce that.
@@ -24,6 +24,6 @@ include("functions.jl")
 include("functions_dims.jl")
 include("functions_math.jl")
 
-@deprecate names dimnames false
+include("deprecations.jl")
 
 end # module

--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -43,7 +43,7 @@ function unwrap_broadcasted(bc::Broadcasted{NamedDimsStyle{S}}) where S
     return Broadcasted{S}(bc.f, inner_args)
 end
 unwrap_broadcasted(x) = x
-unwrap_broadcasted(nda::NamedDimsArray) = parent(nda)
+unwrap_broadcasted(nda::NamedDimsArray) = unname(nda)
 
 
 # We need to implement copy because if the wrapper array type does not support setindex
@@ -59,8 +59,8 @@ end
 function Base.copyto!(dest::AbstractArray, bc::Broadcasted{NamedDimsStyle{S}}) where S
     inner_bc = unwrap_broadcasted(bc)
     copyto!(dest, inner_bc)
-    L = unify_names(dimnames(dest), broadcasted_names(bc))
-    return NamedDimsArray{L}(dest)
+    # Check names compatible, and return refined form (even if can't change `dest`'s names)
+    return refine_names(dest, broadcasted_names(bc))
 end
 
 broadcasted_names(bc::Broadcasted) = broadcasted_names(bc.args...)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,3 @@
+using Base: @deprecate
+@deprecate names dimnames false
+@deprecate (NamedDimsArray{L}(orig::NamedDimsArray) where L)  refine_names(orig, L) false

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,4 @@
 using Base: @deprecate
+
 @deprecate names dimnames false
 @deprecate (NamedDimsArray{L}(orig::NamedDimsArray) where L)  refine_names(orig, L) false

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -47,12 +47,19 @@ end
 @inline NamedDimsArray(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
 @inline NamedDimsArray(orig::AbstractVector, name::Symbol) = NamedDimsArray(orig, (name,))
 
-# Name-asserting constructor (like renaming, but only for wildcards (`:_`).)
-NamedDimsArray{L}(orig::NamedDimsArray{L}) where L = orig
-function NamedDimsArray{L}(orig::NamedDimsArray{old_names, T, N, A}) where {L, old_names, T, N, A}
-    new_names = unify_names(L, old_names)
-    return NamedDimsArray{new_names, T, N, A}(parent(orig))
+"""
+    refine_names(x, names)
+
+Refine the names of the dimensions of `x` to match `names`.
+This is like [`rename`](ref), but it only affects unnamed dimensions.
+I.e. dimensions of a `NamedDimsArray` called `:_`, or any dimensions of an
+`AbstractArray` in general.
+"""
+@inline function refine_names(orig::NamedDimsArray{L}, names::Tuple) where {L}
+    new_names = unify_names(names, L)
+    return NamedDimsArray{new_names}(parent(orig))
 end
+@inline refine_names(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
 
 parent_type(::Type{<:NamedDimsArray{L, T, N, A}}) where {L, T, N, A} = A
 

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,12 @@
+# Has become "refine_names"
+@testset "Name-asserting constructor" begin
+    orig_full = NamedDimsArray(ones(3, 4, 5), (:a, :b, :c))
+    @test dimnames(NamedDimsArray(orig_full, (:a, :b, :c))) == (:a, :b, :c)
+    @test dimnames(NamedDimsArray(orig_full, (:a, :b, :_))) == (:a, :b, :c)
+    @test_throws DimensionMismatch NamedDimsArray(orig_full, (:a, :b, :wrong))
+    @test_throws DimensionMismatch NamedDimsArray(orig_full, (:c, :a, :b))
+
+    orig_partial = NamedDimsArray(ones(3, 4, 5), (:a, :_, :c))
+    @test dimnames(NamedDimsArray(orig_partial, (:a, :b, :c))) == (:a, :b, :c)
+    @test dimnames(NamedDimsArray(orig_partial, (:a, :_, :c))) == (:a, :_, :c)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ const testfiles = (
     "functions_math.jl",
     "broadcasting.jl",
     "tracker_compat.jl",
+    "deprecations.jl"
 )
 
 @testset "NamedDims.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ const testfiles = (
     "functions_math.jl",
     "broadcasting.jl",
     "tracker_compat.jl",
-    "deprecations.jl"
+    "deprecations.jl",
 )
 
 @testset "NamedDims.jl" begin

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -19,16 +19,26 @@ end
 end
 
 
-@testset "Name-asserting constructor" begin
-    orig_full = NamedDimsArray(ones(3, 4, 5), (:a, :b, :c))
-    @test dimnames(NamedDimsArray(orig_full, (:a, :b, :c))) == (:a, :b, :c)
-    @test dimnames(NamedDimsArray(orig_full, (:a, :b, :_))) == (:a, :b, :c)
-    @test_throws DimensionMismatch NamedDimsArray(orig_full, (:a, :b, :wrong))
-    @test_throws DimensionMismatch NamedDimsArray(orig_full, (:c, :a, :b))
+@testset "refine_names" begin
+    @testset "Named Array into a NamedDimsArray" begin
+        nda = refine_names(ones(3, 4, 5), (:a, :b, :c))
+        @test dimnames(nda) == (:a, :b, :c)
+        @test nda isa NamedDimsArray
+    end
 
-    orig_partial = NamedDimsArray(ones(3, 4, 5), (:a, :_, :c))
-    @test dimnames(NamedDimsArray(orig_partial, (:a, :b, :c))) == (:a, :b, :c)
-    @test dimnames(NamedDimsArray(orig_partial, (:a, :_, :c))) == (:a, :_, :c)
+    @testset "Functioning on a fully named NamedDimsArray" begin
+        orig_full = NamedDimsArray(ones(3, 4, 5), (:a, :b, :c))
+        @test dimnames(refine_names(orig_full, (:a, :b, :c))) == (:a, :b, :c)
+        @test dimnames(refine_names(orig_full, (:a, :b, :_))) == (:a, :b, :c)
+        @test_throws DimensionMismatch refine_names(orig_full, (:a, :b, :wrong))
+        @test_throws DimensionMismatch refine_names(orig_full, (:c, :a, :b))
+    end
+
+    @testset "Functioning on a partially named  NamedDimsArray" begin
+        orig_partial = NamedDimsArray(ones(3, 4, 5), (:a, :_, :c))
+        @test dimnames(refine_names(orig_partial, (:a, :b, :c))) == (:a, :b, :c)
+        @test dimnames(refine_names(orig_partial, (:a, :_, :c))) == (:a, :_, :c)
+    end
 end
 
 
@@ -175,9 +185,9 @@ const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
     @test 0 == @allocated parent(cnda)
     @test 0 == @allocated dimnames(cnda)
 
-    @test 0 == @allocated NamedDimsArray(cnda, (:x, :y))
+    @test 0 == @allocated refine_names(cnda, (:x, :y))
     if VERSION >= v"1.1"
-        @test 0 == @allocated NamedDimsArray(cnda, (:x, :_))
+        @test 0 == @allocated refine_names(cnda, (:x, :_))
     else
         @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :_))
     end


### PR DESCRIPTION
This has never sat right with me.
That calling `NamedDimsArray` on a `NamedDimsArray` was the way to coerce wildcard names to have a particular name."

[PyTorch calls this operation `refine_names`](https://pytorch.org/docs/stable/named_tensor.html#torch.Tensor.refine_names)
i think this is a much better name for the function