### PR TITLE
reorganize functions that are only for NamedDimsArrays into their own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ For `nda = NamedDimsArray{(:x, :y, :z)}(rand(10, 20, 30))`.
 
  - Indexing: `nda[y=2]` is the same as `nda[x=:, y=2, z=:]` which is the same as `nda[:, 2, :]`.
  - Functions taking a `dims` keyword: `sum(nda; dims=:y)` is the same as `sum(nda; dims=2)`.
- - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
+
  - Unwrapping: `parent(nda)` returns the underlying `AbstractArray` that is wrapped by the `NamedDimsArray`.
  - Unnaming: `unname(a)` ensures an `AbstractArray` is _not_ a `NamedDimsArray`;
     if passed a `NamedDimsArray` it unwraps it, otherwise just returns the given `AbstractArray`.
+ - Renaming: `rename(nda, new_names)` returns a new `NamedDimsArray` with the `new_names` but still wrapping the same data.
  - Refining Names: `refine_names(nda, names)` returns a new `NamedDimsArray` with any unnamed dimensions of `nda` getting their names from `names`. It errors if any names present in both disagree.
 
 ### Dimensionally Safe Operations

--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -19,7 +19,10 @@ const CoVector = Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:Abst
 
 include("name_core.jl")
 include("wrapper_array.jl")
+include("name_operations.jl")
+
 include("broadcasting.jl")
+
 include("functions.jl")
 include("functions_dims.jl")
 include("functions_math.jl")

--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -1,15 +1,5 @@
 # This file is for functions that explictly mess with the dimensions of a NameDimsArray
 
-"""
-    rename(nda::NamedDimsArray, names)
-
-Returns a new `NameDimsArray` with the given dimension `names`.
-`rename` outright replaces the names; while still wrapping the same backing array.
-Unlike the constructor, it does not require that new names are compatible
-with the old names (though you do still need to match the number of dimensions).
-"""
-rename(nda::NamedDimsArray, names) = NamedDimsArray(parent(nda), names)
-
 function Base.dropdims(nda::NamedDimsArray; dims)
     numerical_dims = dim(nda, dims)
     data = dropdims(parent(nda); dims=numerical_dims)

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -1,0 +1,47 @@
+# This file is for functions that are new functions sepecifically for workin with
+# NamedDimsArrays, rather than overloads of existing functions
+
+"""
+    rename(nda::NamedDimsArray, names)
+
+Returns a new `NameDimsArray` with the given dimension `names`.
+`rename` outright replaces the names; while still wrapping the same backing array.
+Unlike the constructor, it does not require that new names are compatible
+with the old names (though you do still need to match the number of dimensions).
+"""
+rename(nda::NamedDimsArray, names) = NamedDimsArray(parent(nda), names)
+
+"""
+    refine_names(x, names)
+
+Refine the names of the dimensions of `x` to match `names`.
+This is like [`rename`](ref), but it only affects unnamed dimensions.
+I.e. dimensions of a `NamedDimsArray` called `:_`, or any dimensions of an
+`AbstractArray` in general.
+"""
+@inline function refine_names(orig::NamedDimsArray{L}, names::Tuple) where {L}
+    new_names = unify_names(names, L)
+    return NamedDimsArray{new_names}(parent(orig))
+end
+@inline refine_names(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
+
+"""
+    unname(A::NamedDimsArray) -> AbstractArray
+    unname(A::AbstractArray) -> AbstractArray
+
+Return the input array `A` without any dimension names.
+
+For `NamedDimsArray`s this returns the parent array, equivalent to calling `parent`, but for
+any other `AbstractArray` simply returns the input.
+"""
+unname(x::NamedDimsArray) = parent(x)
+unname(x::AbstractArray) = x
+
+"""
+    dimnames(A) -> Tuple
+
+Return the names of all the dimensions of the array `A`.
+"""
+dimnames(::Type{<:NamedDimsArray{L}}) where L = L
+dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
+dimnames(x::T) where T<:AbstractArray = dimnames(T)

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -47,44 +47,10 @@ end
 @inline NamedDimsArray(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
 @inline NamedDimsArray(orig::AbstractVector, name::Symbol) = NamedDimsArray(orig, (name,))
 
-"""
-    refine_names(x, names)
-
-Refine the names of the dimensions of `x` to match `names`.
-This is like [`rename`](ref), but it only affects unnamed dimensions.
-I.e. dimensions of a `NamedDimsArray` called `:_`, or any dimensions of an
-`AbstractArray` in general.
-"""
-@inline function refine_names(orig::NamedDimsArray{L}, names::Tuple) where {L}
-    new_names = unify_names(names, L)
-    return NamedDimsArray{new_names}(parent(orig))
-end
-@inline refine_names(orig::AbstractArray, names::Tuple) = NamedDimsArray{names}(orig)
 
 parent_type(::Type{<:NamedDimsArray{L, T, N, A}}) where {L, T, N, A} = A
 
 Base.parent(x::NamedDimsArray) = getfield(x, :data)
-
-"""
-    unname(A::NamedDimsArray) -> AbstractArray
-    unname(A::AbstractArray) -> AbstractArray
-
-Return the input array `A` without any dimension names.
-
-For `NamedDimsArray`s this returns the parent array, equivalent to calling `parent`, but for
-any other `AbstractArray` simply returns the input.
-"""
-unname(x::NamedDimsArray) = parent(x)
-unname(x::AbstractArray) = x
-
-"""
-    dimnames(A) -> Tuple
-
-Return the names of all the dimensions of the array `A`.
-"""
-dimnames(::Type{<:NamedDimsArray{L}}) where L = L
-dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
-dimnames(x::T) where T<:AbstractArray = dimnames(T)
 
 dim(a::NamedDimsArray{L}, name) where L = dim(L, name)
 

--- a/test/functions_dims.jl
+++ b/test/functions_dims.jl
@@ -3,13 +3,6 @@ using NamedDims
 using NamedDims: names
 using Test
 
-@testset "rename" begin
-    nda = NamedDimsArray{(:a, :b, :c, :d)}(ones(10, 1, 1, 20))
-    new_nda = rename(nda, (:w, :x, :y, :z))
-
-    @test dimnames(new_nda) === (:w, :x, :y, :z)
-    @test parent(new_nda) === parent(nda)
-end
 
 @testset "dropdims" begin
     nda = NamedDimsArray{(:a, :b, :c, :d)}(ones(10, 1, 1, 20))

--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -1,0 +1,42 @@
+@testset "unname" begin
+    for orig in ([1 2; 3 4], spzeros(2, 2))
+        @test unname(NamedDimsArray(orig, (:x, :y))) === orig
+        @test unname(orig) === orig
+    end
+end
+
+@testset "get the names" begin
+    @test dimnames(NamedDimsArray([10 20; 30 40], (:x, :y))) === (:x, :y)
+end
+
+
+@testset "refine_names" begin
+    @testset "Named Array into a NamedDimsArray" begin
+        nda = refine_names(ones(3, 4, 5), (:a, :b, :c))
+        @test dimnames(nda) == (:a, :b, :c)
+        @test nda isa NamedDimsArray
+    end
+
+    @testset "Functioning on a fully named NamedDimsArray" begin
+        orig_full = NamedDimsArray(ones(3, 4, 5), (:a, :b, :c))
+        @test dimnames(refine_names(orig_full, (:a, :b, :c))) == (:a, :b, :c)
+        @test dimnames(refine_names(orig_full, (:a, :b, :_))) == (:a, :b, :c)
+        @test_throws DimensionMismatch refine_names(orig_full, (:a, :b, :wrong))
+        @test_throws DimensionMismatch refine_names(orig_full, (:c, :a, :b))
+    end
+
+    @testset "Functioning on a partially named  NamedDimsArray" begin
+        orig_partial = NamedDimsArray(ones(3, 4, 5), (:a, :_, :c))
+        @test dimnames(refine_names(orig_partial, (:a, :b, :c))) == (:a, :b, :c)
+        @test dimnames(refine_names(orig_partial, (:a, :_, :c))) == (:a, :_, :c)
+    end
+end
+
+
+@testset "rename" begin
+    nda = NamedDimsArray{(:a, :b, :c, :d)}(ones(10, 1, 1, 20))
+    new_nda = rename(nda, (:w, :x, :y, :z))
+
+    @test dimnames(new_nda) === (:w, :x, :y, :z)
+    @test parent(new_nda) === parent(nda)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 const testfiles = (
     "name_core.jl",
     "wrapper_array.jl",
+    "name_operations.jl",
     "functions.jl",
     "functions_dims.jl",
     "functions_math.jl",

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -7,40 +7,8 @@ using Test
 @testset "get the parent array that was wrapped" begin
     for orig in ([1 2; 3 4], spzeros(2, 2))
         @test parent(NamedDimsArray(orig, (:x, :y))) === orig
-
-        @test unname(NamedDimsArray(orig, (:x, :y))) === orig
-        @test unname(orig) === orig
     end
 end
-
-
-@testset "get the named array that was wrapped" begin
-    @test dimnames(NamedDimsArray([10 20; 30 40], (:x, :y))) === (:x, :y)
-end
-
-
-@testset "refine_names" begin
-    @testset "Named Array into a NamedDimsArray" begin
-        nda = refine_names(ones(3, 4, 5), (:a, :b, :c))
-        @test dimnames(nda) == (:a, :b, :c)
-        @test nda isa NamedDimsArray
-    end
-
-    @testset "Functioning on a fully named NamedDimsArray" begin
-        orig_full = NamedDimsArray(ones(3, 4, 5), (:a, :b, :c))
-        @test dimnames(refine_names(orig_full, (:a, :b, :c))) == (:a, :b, :c)
-        @test dimnames(refine_names(orig_full, (:a, :b, :_))) == (:a, :b, :c)
-        @test_throws DimensionMismatch refine_names(orig_full, (:a, :b, :wrong))
-        @test_throws DimensionMismatch refine_names(orig_full, (:c, :a, :b))
-    end
-
-    @testset "Functioning on a partially named  NamedDimsArray" begin
-        orig_partial = NamedDimsArray(ones(3, 4, 5), (:a, :_, :c))
-        @test dimnames(refine_names(orig_partial, (:a, :b, :c))) == (:a, :b, :c)
-        @test dimnames(refine_names(orig_partial, (:a, :_, :c))) == (:a, :_, :c)
-    end
-end
-
 
 @testset "getindex" begin
     nda = NamedDimsArray([10 20; 30 40], (:x, :y))


### PR DESCRIPTION
We have a few of them and they were crowding the already overlong `wrapper_array.jl` file,
except 1 which was in a totally different file with a bunch of overloaded functions