### PR TITLE
dimnames(A, d)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.17"
+version = "0.2.18"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -39,8 +39,13 @@ unname(x::AbstractArray) = x
 
 """
     dimnames(A) -> Tuple
+    dimnames(A, d) -> Symbol
 
-Return the names of all the dimensions of the array `A`.
+Return the names of all the dimensions of the array `A`, 
+or just the one for the `d`-th dimension. 
+
+Gives wildcards `:_` if this is not a `NamedDimsArray`.
+And like `size(A, d)`, it allows `d > ndims(A)`.
 """
 dimnames(::Type{<:NamedDimsArray{L}}) where {L} = L
 dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -57,7 +57,7 @@ function dimnames(AT::Type{<:AbstractArray{T,N}}, d::Integer) where {T,N}
     elseif d>N
         return :_
     else
-        error("dimnames: dimension out of range")
+        throw(DimensionMismatch("dimnames: dimension out of range"))
     end
 end
 dimnames(x::T, d::Integer) where T<:AbstractArray = dimnames(T, d)

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -42,6 +42,17 @@ unname(x::AbstractArray) = x
 
 Return the names of all the dimensions of the array `A`.
 """
-dimnames(::Type{<:NamedDimsArray{L}}) where L = L
+dimnames(::Type{<:NamedDimsArray{L}}) where {L} = L
 dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
 dimnames(x::T) where T<:AbstractArray = dimnames(T)
+
+function dimnames(AT::Type{<:AbstractArray{T,N}}, d::Integer) where {T,N}
+    if d in 1:N
+        return dimnames(AT)[d]
+    elseif d>N
+        return :_
+    else
+        error("dimnames: dimension out of range")
+    end
+end
+dimnames(x::T, d::Integer) where T<:AbstractArray = dimnames(T, d)

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -52,9 +52,9 @@ dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
 dimnames(x::T) where T<:AbstractArray = dimnames(T)
 
 function dimnames(AT::Type{<:AbstractArray{T,N}}, d::Integer) where {T,N}
-    if d in 1:N
+    if 1 <= d <= N
         return dimnames(AT)[d]
-    elseif d>N
+    elseif d > N
         return :_
     else
         throw(DimensionMismatch("dimnames: dimension out of range"))

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -45,7 +45,7 @@ Return the names of all the dimensions of the array `A`,
 or just the one for the `d`-th dimension. 
 
 Gives wildcards `:_` if this is not a `NamedDimsArray`.
-And like `size(A, d)`, it allows `d > ndims(A)`.
+Like `size(A, d)`, it allows `d > ndims(A)`, in this case all the trailing dimension are given the wildcard name (`:_`).
 """
 dimnames(::Type{<:NamedDimsArray{L}}) where {L} = L
 dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)

--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -5,8 +5,19 @@
     end
 end
 
-@testset "get the names" begin
-    @test dimnames(NamedDimsArray([10 20; 30 40], (:x, :y))) === (:x, :y)
+
+@testset "dimnames" begin
+    nda = NamedDimsArray([10 20; 30 40], (:x, :y))
+
+    @test dimnames(nda) === (:x, :y)
+    @test dimnames(nda, 2) === :y
+    @test dimnames(nda, 3) === :_
+
+    @test dimnames([10 20; 30 40]) === (:_, :_)
+    @test dimnames([10 20; 30 40], 2) === :_
+    @test dimnames([10 20; 30 40], 3) === :_
+
+    @test_throws Exception dimnames(nda, 0)
 end
 
 

--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -6,7 +6,7 @@
 end
 
 
-@testset "dimnames" begin
+@testset "dimnames" begin   
     nda = NamedDimsArray([10 20; 30 40], (:x, :y))
 
     @test dimnames(nda) === (:x, :y)
@@ -16,6 +16,9 @@ end
     @test dimnames([10 20; 30 40]) === (:_, :_)
     @test dimnames([10 20; 30 40], 2) === :_
     @test dimnames([10 20; 30 40], 3) === :_
+    
+    v = NamedDimsArray(1:2, :a)
+    @test dimnames(v, 2) == dimnames(permutedims(v), 1) # That's why :_ for d > ndims
 
     @test_throws Exception dimnames(nda, 0)
 end


### PR DESCRIPTION
If `dimnames` is the official way to extract names, then perhaps `dimnames(A, d)` ought to work like `size(A, d)`. 