### PR TITLE
Mark allocation tests broken in julia 1.4

### DIFF
--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -1,5 +1,3 @@
-using SparseArrays
-
 @testset "unname" begin
     for orig in ([1 2; 3 4], spzeros(2, 2))
         @test unname(NamedDimsArray(orig, (:x, :y))) === orig

--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -1,3 +1,5 @@
+using SparseArrays
+
 @testset "unname" begin
     for orig in ([1 2; 3 4], spzeros(2, 2))
         @test unname(NamedDimsArray(orig, (:x, :y))) === orig

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using NamedDims
 using BenchmarkTools
+using SparseArrays
 using Test
 
 const testfiles = (

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -231,10 +231,14 @@ const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
     @test 0 == @ballocated dimnames(cnda)
 
     # These tests use `@allocated` as for some reason `@ballocated` reports 1 alloc
-    @test 0 == @allocated NamedDimsArray(cnda, (:x, :y))
-    if VERSION >= v"1.1"
+    if VERSION >= v"1.4"
+        @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :y))
+        @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :_))
+    elseif VERSION >= v"1.1"
+        @test 0 == @allocated NamedDimsArray(cnda, (:x, :y))
         @test 0 == @allocated NamedDimsArray(cnda, (:x, :_))
     else
+        @test 0 == @allocated NamedDimsArray(cnda, (:x, :y))
         @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :_))
     end
 

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -231,7 +231,7 @@ const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
     @test 0 == @ballocated dimnames(cnda)
 
     # These tests use `@allocated` as for some reason `@ballocated` reports 1 alloc
-    if VERSION >= v"1.4"
+    if VERSION >= v"1.4" # see https://github.com/invenia/NamedDims.jl/issues/115
         @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :y))
         @test_broken 0 == @allocated NamedDimsArray(cnda, (:x, :_))
     elseif VERSION >= v"1.1"


### PR DESCRIPTION
Relates to tests in #115 .

The `using SparseArrays` makes sure the tests in `name_operations.jl` can run standalone. Sorry for including it here, added this commit earlier and it slipped in here. 