### PR TITLE
Resolve method ambiguity on Adjoint and Diagonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -83,7 +83,7 @@ end
 # but that overwrites existing *(1D NDA, Vector) methods
 # should improve the macro above to deal with this case
 function Base.:*(a::Diagonal, b::NamedDimsArray{<:Any, <:Any, 1})
-    return *(NamedDims.NamedDimsArray{dimnames(a)}(a), b)
+    return *(NamedDimsArray{dimnames(a)}(a), b)
 end
 
 function Base.:*(a::NamedDimsArray{<:Any, <:Any, 1}, b::Diagonal)

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -78,9 +78,20 @@ macro declare_matmul(MatrixT, VectorT=nothing)
     return esc(Expr(:block, codes...))
 end
 
+# The following two methods can be defined by using
+# @declare_matmul(Diagonal, AbstractVector)
+# but that overwrites existing *(1D NDA, Vector) methods
+# should improve the macro above to deal with this case
+function Base.:*(a::Diagonal, b::NamedDimsArray{<:Any, <:Any, 1})
+    return *(NamedDims.NamedDimsArray{dimnames(a)}(a), b)
+end
+
+function Base.:*(a::NamedDimsArray{<:Any, <:Any, 1}, b::Diagonal)
+    return *(a, NamedDims.NamedDimsArray{dimnames(b)}(b))
+end
+
 @declare_matmul(AbstractMatrix, AbstractVector)
 @declare_matmul(Adjoint{<:Any, <:AbstractMatrix{T1}} where T1, Adjoint{<:Any, <:AbstractVector})
-@declare_matmul(Diagonal, AbstractVector)
 @declare_matmul(Diagonal,)
 
 function Base.inv(nda::NamedDimsArray{L, T, 2}) where {L,T}

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -43,8 +43,12 @@ function Base.:*(a::NamedDimsArray{L,T,2,<:CoVector}, b::AbstractVector) where {
     return *(parent(a), b)
 end
 
-# Using `CovVector` results in Method ambiguities; have to define more specific methods.
-for A in (Adjoint{<:Any, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
+# Using `CoVector` results in Method ambiguities; have to define more specific methods.
+specifics = (Adjoint{<:Any, <:AbstractVector},
+             Adjoint{<:Any, <:AbstractMatrix{T1}} where T1,
+             Transpose{<:Real, <:AbstractVector{<:Real}},
+             Diagonal{<:Any})
+for A in specifics
     @eval function Base.:*(a::$A, b::NamedDimsArray{L,T,1,<:AbstractVector{T}}) where {L,T}
         return *(a, parent(b))
     end

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -43,12 +43,8 @@ function Base.:*(a::NamedDimsArray{L,T,2,<:CoVector}, b::AbstractVector) where {
     return *(parent(a), b)
 end
 
-# Using `CoVector` results in Method ambiguities; have to define more specific methods.
-specifics = (Adjoint{<:Any, <:AbstractVector},
-             Adjoint{<:Any, <:AbstractMatrix{T1}} where T1,
-             Transpose{<:Real, <:AbstractVector{<:Real}},
-             Diagonal{<:Any})
-for A in specifics
+# Using `CovVector` results in Method ambiguities; have to define more specific methods.
+for A in (Adjoint{<:Any, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
     @eval function Base.:*(a::$A, b::NamedDimsArray{L,T,1,<:AbstractVector{T}}) where {L,T}
         return *(a, parent(b))
     end

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -83,6 +83,8 @@ macro declare_matmul(MatrixT, VectorT=nothing)
 end
 
 @declare_matmul(AbstractMatrix, AbstractVector)
+@declare_matmul(Adjoint{<:Any, <:AbstractMatrix{T1}} where T1, Adjoint{<:Any, <:AbstractVector})
+@declare_matmul(Diagonal, AbstractVector)
 @declare_matmul(Diagonal,)
 
 function Base.inv(nda::NamedDimsArray{L, T, 2}) where {L,T}

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -43,7 +43,7 @@ function Base.:*(a::NamedDimsArray{L,T,2,<:CoVector}, b::AbstractVector) where {
     return *(parent(a), b)
 end
 
-# Using `CovVector` results in Method ambiguities; have to define more specific methods.
+# Using `CoVector` results in Method ambiguities; have to define more specific methods.
 for A in (Adjoint{<:Any, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
     @eval function Base.:*(a::$A, b::NamedDimsArray{L,T,1,<:AbstractVector{T}}) where {L,T}
         return *(a, parent(b))

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -87,7 +87,7 @@ function Base.:*(a::Diagonal, b::NamedDimsArray{<:Any, <:Any, 1})
 end
 
 function Base.:*(a::NamedDimsArray{<:Any, <:Any, 1}, b::Diagonal)
-    return *(a, NamedDims.NamedDimsArray{dimnames(b)}(b))
+    return *(a, NamedDimsArray{dimnames(b)}(b))
 end
 
 @declare_matmul(AbstractMatrix, AbstractVector)

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -159,12 +159,27 @@ end
 
 
 @testset "Mutmul with special types" begin
-    nda = NamedDimsArray{(:a, :b)}(ones(5,5))
-    @testset "$T" for T in (Diagonal, Symmetric, Tridiagonal, SymTridiagonal, BitArray,)
-        x = T(ones(5,5))
-        @test dimnames(x * nda) == (:_, :b)
-        @test dimnames(nda * x) == (:a, :_)
+
+    special_types = (Adjoint, Diagonal, Symmetric, Tridiagonal, SymTridiagonal, BitArray,)
+
+    @testset "matrix" begin
+        ndm = NamedDimsArray{(:a, :b)}(ones(5,5))
+        @testset "$T" for T in special_types
+            x = T(ones(5,5))
+            @test dimnames(x * ndm) == (:_, :b)
+            @test dimnames(ndm * x) == (:a, :_)
+        end
     end
+
+    @testset "vector" begin
+        ndv = NamedDimsArray{(:vec,)}(ones(5))
+        @testset "$T" for T in special_types
+            x = T(ones(5,5))
+            @test dimnames(x * ndv) == (:_,)
+            @test dimnames(ndv' * x) == (:_, :_)
+        end
+    end
+
 end
 
 

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -168,6 +168,9 @@ end
             x = T(ones(5,5))
             @test dimnames(x * ndm) == (:_, :b)
             @test dimnames(ndm * x) == (:a, :_)
+
+            @test typeof(x * ndm) <: NamedDimsArray
+            @test typeof(ndm * x) <: NamedDimsArray
         end
     end
 
@@ -177,6 +180,9 @@ end
             x = T(ones(5,5))
             @test dimnames(x * ndv) == (:_,)
             @test dimnames(ndv' * x) == (:_, :_)
+
+            @test typeof(x * ndv) <: NamedDimsArray
+            @test typeof(ndv' * x) <: NamedDimsArray
         end
     end
 


### PR DESCRIPTION
Adds tests and the two methods which resolve the ambiguities. Closes #112 and #60.