### PR TITLE
fix tests for count with dims argument for julia 1.5

### DIFF
--- a/test/functions.jl
+++ b/test/functions.jl
@@ -167,8 +167,13 @@ using Statistics
         nda = NamedDimsArray(a, (:x, :y))
 
         @test count(nda) == count(a) == 3
-        @test_throws Exception count(nda; dims=:x)
-        @test_throws Exception count(a; dims=1)
+
+        if VERSION >= v"1.5"
+            @test parent(count(nda, dims=:x)) == count(a, dims=1) == [2 1]
+        else
+            @test_throws Exception count(nda; dims=:x)
+            @test_throws Exception count(a; dims=1)
+        end
     end
 
     @testset "push!, pop!, etc" begin

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -170,6 +170,8 @@ using Statistics
 
         if VERSION >= v"1.5"
             @test parent(count(nda, dims=:x)) == count(a, dims=1) == [2 1]
+            @test dimnames(count(nda, dims=:x)) ==
+                  dimnames(count(nda, dims=:y)) == (:x, :y)
         else
             @test_throws Exception count(nda; dims=:x)
             @test_throws Exception count(a; dims=1)


### PR DESCRIPTION
In [julia 1.5](https://docs.julialang.org/en/v1/NEWS/) count accepts dims argument, which fails two tests in `test/functions.jl`.

https://github.com/invenia/NamedDims.jl/blob/32d8f693b6ed8e1d1eec9104b0e9d3f61de896af/test/functions.jl#L170-L171

At present the behaviour is:
```
julia> a = [true false; true true];

julia> nda = NamedDimsArray(a, (:x, :y));

julia> count(nda, dims=:x)
1×2 NamedDimsArray{(:x, :y),Int64,2,Array{Int64,2}}:
 2  1
```

It seems reasonable to me that an NDA is returned, rather than an array. Do people have different opinions?