### PR TITLE
Fix a bug affecting NDAs constructed from CoVectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.23"
+version = "0.2.24"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -35,7 +35,7 @@ end
 
 # vector^T * vector
 function Base.:*(a::NamedDimsArray{A,T,2,<:CoVector}, b::NamedDimsArray{B,S,1}) where {A,B,T,S}
-    last(A) === first(B) || throw_matrix_dim_error(last(A), first(B))
+    valid_matmul_dims(A, B) || throw_matrix_dim_error(last(A), first(B))
     return *(parent(a), parent(b))
 end
 

--- a/test/functions_math.jl
+++ b/test/functions_math.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 using NamedDims
 using NamedDims: matrix_prod_names, names, symmetric_names
 using Test
-
+using Statistics
 
 @testset "+" begin
     nda = NamedDimsArray{(:a,)}(ones(3))
@@ -150,6 +150,13 @@ end
 
         ndv2 = NamedDimsArray{(:b,)}([3, 2, 1])
         @test_throws DimensionMismatch ndv' * ndv2
+    end
+
+    @testset "NDAs from CoVectors" begin
+        v = [1, 2, 3]
+        ndv = NamedDimsArray{(:vec,)}(v)
+        @test NamedDimsArray{dimnames(v')}(v') * ndv == 14
+        @test NamedDimsArray{dimnames(v')}(transpose(v)) * ndv == 14
     end
 end
 @testset "allocations: matmul names" begin


### PR DESCRIPTION
Fixes small bug affecting NDAs constructed from CoVectors:

```
julia> v = [1, 2, 3];

julia> ndv = NamedDimsArray{(:vec, )}(v)
3-element NamedDimsArray{(:vec,),Int64,1,Array{Int64,1}}:
 1
 2
 3
```

before the fix:
```
julia> NamedDimsArray{(:_, :_)}(v') * ndv
ERROR: DimensionMismatch("Cannot take matrix product of arrays with different inner dimension names. _ vs vec")
Stacktrace:
 [1] throw_matrix_dim_error(::Symbol, ::Symbol) at /Users/mzgubic/.julia/dev/NamedDims.jl/src/functions_math.jl:18
 [2] *(::NamedDimsArray{(:_, :_),Int64,2,Adjoint{Int64,Array{Int64,1}}}, ::NamedDimsArray{(:vec,),Int64,1,Array{Int64,1}}) at /Users/mzgubic/.julia/dev/NamedDims.jl/src/functions_math.jl:38
 [3] top-level scope at REPL[75]:1
```

after the fix:
```
julia> NamedDimsArray{dimnames(v')}(v') * ndv
14
```