### PR TITLE
fix ambiguity on julia 1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.24"
+version = "0.2.25"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -44,7 +44,7 @@ function Base.:*(a::NamedDimsArray{L,T,2,<:CoVector}, b::AbstractVector) where {
 end
 
 # Using `CoVector` results in Method ambiguities; have to define more specific methods.
-for A in (Adjoint{<:Any, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
+for A in (Adjoint{<:Number, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
     @eval function Base.:*(a::$A, b::NamedDimsArray{L,T,1,<:AbstractVector{T}}) where {L,T}
         return *(a, parent(b))
     end

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -80,7 +80,7 @@ This expands the `dimnames` if `name` is not in `dimnames`.
 e.g. `expand_dimnames((:a, :b), :c) == (:a, :b, :c)`
 If `name` is already in `dimnames` then `dimnames` is returned.
 """
-@inline function expand_dimnames(dimnames::Tuple, name::Symbol)
+function expand_dimnames(dimnames::Tuple, name::Symbol)
     if dim_noerror(dimnames, name) > 0  # name in dimnames, but optimised
         return dimnames
     else
@@ -88,11 +88,11 @@ If `name` is already in `dimnames` then `dimnames` is returned.
     end
 end
 
-@inline function expand_dimnames(dimnames::Tuple, name::Union{Colon, Tuple{}})
+function expand_dimnames(dimnames::Tuple, name::Union{Colon, Tuple{}})
     return dimnames
 end
 
-@inline function expand_dimnames(dimnames::Tuple, name::Integer)
+function expand_dimnames(dimnames::Tuple, name::Integer)
     if name <= length(dimnames)
         return dimnames
     else
@@ -102,7 +102,7 @@ end
     end
 end
 
-@inline function expand_dimnames(dimnames::Tuple, names)
+function expand_dimnames(dimnames::Tuple, names)
     return expand_dimnames(
         expand_dimnames(dimnames, first(names)),
         Base.tail(names),

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -80,32 +80,34 @@ This expands the `dimnames` if `name` is not in `dimnames`.
 e.g. `expand_dimnames((:a, :b), :c) == (:a, :b, :c)`
 If `name` is already in `dimnames` then `dimnames` is returned.
 """
-function expand_dimnames(dimnames::Tuple, name::Symbol)
+@inline function expand_dimnames(dimnames::Tuple, name::Symbol)
     if dim_noerror(dimnames, name) > 0  # name in dimnames, but optimised
         return dimnames
     else
-        return (dimnames..., name)
+        return compile_time_return_hack((dimnames..., name))
     end
 end
 
-function expand_dimnames(dimnames::Tuple, name::Union{Colon, Tuple{}})
+@inline function expand_dimnames(dimnames::Tuple, name::Union{Colon, Tuple{}})
     return dimnames
 end
 
-function expand_dimnames(dimnames::Tuple, name::Integer)
+@inline function expand_dimnames(dimnames::Tuple, name::Integer)
     if name <= length(dimnames)
         return dimnames
     else
         extra_length = name - length(dimnames)
         new_dimnames = ntuple(i->:_, extra_length)
-        return (dimnames..., new_dimnames...)
+        return compile_time_return_hack((dimnames..., new_dimnames...))
     end
 end
 
-function expand_dimnames(dimnames::Tuple, names)
-    expand_dimnames(expand_dimnames(dimnames, names[1]), names[2:end])
+@inline function expand_dimnames(dimnames::Tuple, names)
+    return expand_dimnames(
+        expand_dimnames(dimnames, first(names)),
+        Base.tail(names),
+    )
 end
-
 
 """
     permute_dimnames(dimnames, perm)

--- a/test/name_core.jl
+++ b/test/name_core.jl
@@ -15,7 +15,6 @@ using NamedDims:
     remaining_dimnames_after_dropping
 using Test
 
-
 @testset "dim" begin
     @testset "small case" begin
         @test dim((:x, :y), :x) == 1
@@ -32,11 +31,7 @@ end
 @testset "allocations: dim" begin
     @test 0 == @ballocated (()->dim((:a, :b), :b))()
     @test 0 == @ballocated (()->dim_noerror((:a, :b, :c), :c))()
-    if VERSION >= v"1.1"
-        @test 0 == @ballocated (()->dim((:a,:b), (:a,:b)))()
-    else
-        @test_broken 0 == @ballocated (()->dim((:a,:b), (:a,:b)))()
-    end
+    @test_modern 0 == @ballocated (()->dim((:a,:b), (:a,:b)))()
 end
 
 
@@ -79,27 +74,14 @@ end
 end
 @testset "allocations: unify_names_*" begin
     for unify in (unify_names, unify_names_longest, unify_names_shortest)
-        if VERSION >= v"1.1"
-            @test 0 == @ballocated (()->$unify((:a, :b), (:a, :_)))()
-        else
-            @test_broken 0 == @ballocated (()->$unify((:a, :b), (:a, :_)))()
-        end
+        @test_modern 0 == @ballocated (()->$unify((:a, :b), (:a, :_)))()
     end
-    if VERSION >= v"1.1"
-        @test 0 == @ballocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
-        @test 0 == @ballocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
-        @test 0 == @ballocated (()->unify_names_longest((:a,), (:a, :b), (:a, :_, :c)))()
-        @test 0 == @ballocated (()->unify_names_shortest((:a,), (:a, :b), (:a, :_, :c)))()
-        @test 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :_)))()
-        @test 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :c)))()
-    else
-        @test_broken 0 == @ballocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
-        @test_broken 0 == @ballocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
-        @test_broken 0 == @ballocated (()->unify_names_longest((:a,), (:a, :b), (:a, :_, :c)))()
-        @test_broken 0 == @ballocated (()->unify_names_shortest((:a,), (:a, :b), (:a, :_, :c)))()
-        @test_broken 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :_)))()
-        @test_broken 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :c)))()
-    end
+    @test_modern 0 == @ballocated (()->unify_names_longest((:a, :b), (:a, :_, :c)))()
+    @test_modern 0 == @ballocated (()->unify_names_shortest((:a, :b), (:a, :_, :c)))()
+    @test_modern 0 == @ballocated (()->unify_names_longest((:a,), (:a, :b), (:a, :_, :c)))()
+    @test_modern 0 == @ballocated (()->unify_names_shortest((:a,), (:a, :b), (:a, :_, :c)))()
+    @test_modern 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :_)))()
+    @test_modern 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :c)))()
     @test 0 == @ballocated (()->names_are_unifiable((:a, :b), (:a, :b)))()
 end
 
@@ -131,13 +113,13 @@ end
     @testset "names" begin
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), :x))()
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), :z))()
-        @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), (:x, :z)))()
+        @test_modern 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), (:x, :z)))()
     end
 
     @testset "numbers et al" begin
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), 1))()
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), 5))()
-        @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), (1, 5)))()
+        @test_modern 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), (1, 5)))()
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), :))()
         @test 0 == @ballocated (()->NamedDims.expand_dimnames((:x, :y), ()))()
     end
@@ -203,9 +185,7 @@ end
     @test_throws BoundsError permute_dimnames((:a, :b), (1, 0))
 end
 @testset "allocations: permute_dimnames" begin
-    if VERSION >= v"1.1"
-        @test 0 == @ballocated permute_dimnames((:a,:b,:c), (1,3,2))
-    end
+    @test_modern 0 == @ballocated permute_dimnames((:a,:b,:c), (1,3,2))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using BenchmarkTools
 using SparseArrays
 using Test
 
+include("test_helpers.jl")
+
 const testfiles = (
     "name_core.jl",
     "wrapper_array.jl",

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -1,0 +1,15 @@
+"""
+    @test_modern
+
+Use this to mark tests that should pass on modern (>=v1.1) versions of julia,
+but should be marked as `@test_broken` on Julia 1.0.
+For more complicated cases, or where it shouldn't be defined at all on julia versions,
+you can use `if VERSION` directly.
+"""
+macro test_modern(expr...)
+    if VERSION >= v"1.1"
+        return :(@test $(expr...))
+    else
+        return :(@test_broken $(expr...))
+    end
+end


### PR DESCRIPTION
Closes #112
Makes #128 redundant

Cause is:
https://github.com/JuliaLang/julia/pull/36679
 removed a defintiion of matmul with `Adjoint{<:Any}` and replaced it with one with `Adjoint{<:Number}`
we were winning that ambiguity fight before, but now it ties.
This PR changes us to match.