### PR TITLE
Only test LTS and stable

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.1
+  - julia_version: 1
   - julia_version: nightly
 platform:
   - x86


### PR DESCRIPTION
Tests are actually failing on 1.1 right now, we only really are interested in supporting  testing LTS and Stable.
The failures are pretty meaningless