### PR TITLE
`hcat` tricky cases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.26"
+version = "0.2.27"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -5,24 +5,6 @@ function Base.cat(a::NamedDimsArray{L}; dims) where L
     return NamedDimsArray{newL}(data)
 end
 
-# While the following two functions are covered by the general case below where splatted c
-# is empty, they are included because they reduce allocations to that of regular arrays.
-function Base.cat(a::NamedDimsArray{L}, b::AbstractArray; dims) where L
-    newL = expand_dimnames(L, dims)
-    numerical_dims = dim(newL, dims)
-    data = Base.cat(parent(a), b; dims=numerical_dims)
-    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
-end
-
-function Base.cat(a::AbstractArray, b::NamedDimsArray{L}; dims) where L
-    newL = expand_dimnames(L, dims)
-    numerical_dims = dim(newL, dims)
-    data = Base.cat(a, parent(b); dims=numerical_dims)
-    T = promote_type(eltype(a), eltype(b))
-    N = length(newL)
-    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
-end
-
 # to dispatch on the first _or the second_ argument being the NDA.
 for (T, S) in [
     (:NamedDimsArray, :AbstractArray),
@@ -62,4 +44,3 @@ for (T, S) in [
         end
     end
 end
-

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -2,9 +2,7 @@ function Base.cat(a::NamedDimsArray{L}; dims) where L
     newL = expand_dimnames(L, dims)
     numerical_dims = dim(newL, dims)
     data = Base.cat(parent(a); dims=numerical_dims) # Base.cat is type unstable
-    T = eltype(a)  # therefore the element type has to be inferred manually
-    N = length(newL)  # as must the size of the array
-    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
+    return NamedDimsArray{newL}(data)
 end
 
 # While the following two functions are covered by the general case below where splatted c
@@ -37,14 +35,14 @@ for (T, S) in [
         newL = expand_dimnames(combL, dims)
         numerical_dims = dim(newL, dims)
         data = Base.cat(unname(a), unname(b), unname.(cs)...; dims=numerical_dims)
-        return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
+        return NamedDimsArray{newL}(data)
     end
 end
 
 function Base.hcat(a::NamedDimsArray{L}) where L
     newL = expand_dimnames(L, 2)
     data = Base.hcat(parent(a))
-    return NamedDimsArray{newL, eltype(a), ndims(data), typeof(data)}(data)
+    return NamedDimsArray{newL}(data)
 end
 
 Base.vcat(a::NamedDimsArray{L}) where L = a
@@ -60,7 +58,7 @@ for (T, S) in [
             combL = unify_names_longest(dimnames(a), dimnames(b), dimnames.(cs)...)
             newL = expand_dimnames(combL, $d)
             data = Base.$fun(unname(a), unname(b), unname.(cs)...)
-            return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
+            return NamedDimsArray{newL}(data)
         end
     end
 end

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -4,7 +4,7 @@ function Base.cat(a::NamedDimsArray{L}; dims) where L
     data = Base.cat(parent(a); dims=numerical_dims) # Base.cat is type unstable
     T = eltype(a)  # therefore the element type has to be inferred manually
     N = length(newL)  # as must the size of the array
-    return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
 end
 
 # While the following two functions are covered by the general case below where splatted c
@@ -13,9 +13,7 @@ function Base.cat(a::NamedDimsArray{L}, b::AbstractArray; dims) where L
     newL = expand_dimnames(L, dims)
     numerical_dims = dim(newL, dims)
     data = Base.cat(parent(a), b; dims=numerical_dims)
-    T = promote_type(eltype(a), eltype(b))
-    N = length(newL)
-    return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
 end
 
 function Base.cat(a::AbstractArray, b::NamedDimsArray{L}; dims) where L
@@ -24,7 +22,7 @@ function Base.cat(a::AbstractArray, b::NamedDimsArray{L}; dims) where L
     data = Base.cat(a, parent(b); dims=numerical_dims)
     T = promote_type(eltype(a), eltype(b))
     N = length(newL)
-    return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+    return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
 end
 
 # to dispatch on the first _or the second_ argument being the NDA.
@@ -34,56 +32,36 @@ for (T, S) in [
     (:NamedDimsArray, :NamedDimsArray)
     ]
 
-    @eval function Base.cat(a::$T, b::$S, c::AbstractArray...; dims)
-        combL = unify_names_shortest(dimnames(a), dimnames(b), ntuple(i->dimnames(c[i]), length(c))...)
+    @eval function Base.cat(a::$T, b::$S, cs::AbstractArray...; dims)
+        combL = unify_names_longest(dimnames(a), dimnames(b), dimnames.(cs)...)
         newL = expand_dimnames(combL, dims)
         numerical_dims = dim(newL, dims)
-        data = Base.cat(parent(a), parent(b), ntuple(i->parent(c[i]), length(c))...; dims=numerical_dims)
-        T = promote_type(eltype(a), eltype(b), ntuple(i->eltype(c[i]), length(c))...)
-        N = length(newL)
-        return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+        data = Base.cat(unname(a), unname(b), unname.(cs)...; dims=numerical_dims)
+        return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
     end
 end
 
-# vcat and hcat
 function Base.hcat(a::NamedDimsArray{L}) where L
     newL = expand_dimnames(L, 2)
     data = Base.hcat(parent(a))
-    T = eltype(a)
-    N = length(newL)
-    return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+    return NamedDimsArray{newL, eltype(a), ndims(data), typeof(data)}(data)
 end
 
 Base.vcat(a::NamedDimsArray{L}) where L = a
 
-# Base.hcat and Base.vcat specialise on this Union
-const AbsVecOrMat = Union{AbstractVector, AbstractMatrix}
 for (T, S) in [
-    (:NamedDimsArray, :AbsVecOrMat),
-    (:NamedDimsArray, :AbstractArray),
-    (:AbsVecOrMat, :NamedDimsArray),
-    (:AbstractArray, :NamedDimsArray),
-    (:NamedDimsArray, :NamedDimsArray)
+    (:NamedDimsVecOrMat, :NamedDimsVecOrMat),
+    (:NamedDimsVecOrMat, :AbstractVecOrMat),
+    (:AbstractVecOrMat, :NamedDimsVecOrMat),
     ]
-
     for (fun, d) in zip((:vcat, :hcat), (1, 2))
-        # this special case is needed to resolve ambiguities
-        @eval function Base.$fun(a::$T, b::$S)
-            combL = unify_names_shortest(dimnames(a), dimnames(b))
-            newL = expand_dimnames(combL, $d)
-            data = Base.$fun(parent(a), parent(b))
-            T = promote_type(eltype(a), eltype(b))
-            N = length(newL)
-            return NamedDimsArray{newL, T, N, Array{T,N}}(data)
-        end
 
-        @eval function Base.$fun(a::$T, b::$S, c::NamedDimsArray...)
-            combL = unify_names_shortest(dimnames(a), dimnames(b), ntuple(i->dimnames(c[i]), length(c))...)
+        @eval function Base.$fun(a::$T, b::$S, cs::AbstractVecOrMat...)
+            combL = unify_names_longest(dimnames(a), dimnames(b), dimnames.(cs)...)
             newL = expand_dimnames(combL, $d)
-            data = Base.$fun(parent(a), parent(b), ntuple(i->parent(c[i]), length(c))...)
-            T = promote_type(eltype(a), eltype(b), ntuple(i->eltype(c[i]), length(c))...)
-            N = length(newL)
-            return NamedDimsArray{newL, T, N, Array{T,N}}(data)
+            data = Base.$fun(unname(a), unname(b), unname.(cs)...)
+            return NamedDimsArray{newL, eltype(data), ndims(data), typeof(data)}(data)
         end
     end
 end
+

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -63,6 +63,8 @@ function dim(dimnames::Tuple, d::Union{Integer, Colon})
     return d
 end
 
+dim(dimnames::Tuple, ::Val{d}) where {d} = dim(dimnames, d)
+
 Base.@pure function dim_noerror(dimnames::Tuple{Vararg{Symbol, N}}, name::Symbol) where N
     # 0-Allocations see: @btime  (()->dim_noerror((:a, :b, :c), :c))()
     for ii in 1:N
@@ -108,6 +110,9 @@ function expand_dimnames(dimnames::Tuple, names)
         Base.tail(names),
     )
 end
+
+expand_dimnames(dimnames::Tuple, ::Val{d}) where {d} = expand_dimnames(dimnames, d)
+
 
 """
     permute_dimnames(dimnames, perm)

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -61,6 +61,7 @@ Base.parent(x::NamedDimsArray) = getfield(x, :data)
 dim(a::NamedDimsArray{L}, name) where L = dim(L, name)
 
 NamedDimsVecOrMat{L,T} = Union{NamedDimsArray{L,T,1}, NamedDimsArray{L,T,2}}
+NamedDimsVector{L,T} = NamedDimsArray{L,T,1}
 
 #############################
 # AbstractArray Interface

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -60,6 +60,7 @@ Base.parent(x::NamedDimsArray) = getfield(x, :data)
 
 dim(a::NamedDimsArray{L}, name) where L = dim(L, name)
 
+NamedDimsVecOrMat{L,T} = Union{NamedDimsArray{L,T,1}, NamedDimsArray{L,T,2}}
 
 #############################
 # AbstractArray Interface

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -104,29 +104,26 @@ for (f, d) in zip((vcat, hcat), (1, 2))
         @test_throws Exception cat(ndt, parent(ndt), permutedims(ndt, (3,2,1)), dims=2)
 
     end
-end
+    @testset "tricky cases" begin
+        r23 = rand(Int8, 2,3)
+        nda = NamedDimsArray(rand(2,3), (:x, :y))
+        ndv = NamedDimsArray(rand(2), (:x,))
 
-@testset "tricky cases" begin
+        @test dimnames(hcat(nda, ndv)) == (:x, :y)
+        @test dimnames(cat(nda, ndv, dims=2)) == (:x, :y)
 
-    r23 = rand(Int8, 2,3)
-    nda = NamedDimsArray(rand(2,3), (:x, :y))
-    ndv = NamedDimsArray(rand(2), (:x,))
+        @test dimnames(hcat(r23', nda', nda')) == (:y, :x)
+        @test dimnames(cat(r23', nda', nda', dims=2)) == (:y, :x)
 
-    @test dimnames(hcat(nda, ndv)) == (:x, :y)
-    @test dimnames(cat(nda, ndv, dims=2)) == (:x, :y)
+        @test_throws Exception hcat(nda, r23')
+        @test_throws Exception cat(nda, r23', dims=2)
 
-    @test dimnames(hcat(r23', nda', nda')) == (:y, :x)
-    @test dimnames(cat(r23', nda', nda', dims=2)) == (:y, :x)
+        @test size(cat(nda', r23', nda', dims=(:x, :y))) == (9,6)
+        @test dimnames(cat(nda', r23', nda', dims=(1,2))) == (:y, :x)
 
-    @test_throws Exception hcat(nda, r23')
-    @test_throws Exception cat(nda, r23', dims=2)
+        @test dimnames(cat(1:2, ndv, [5 6]', dims=:z)) == (:x, :_, :z)
 
-    @test size(cat(nda', r23', nda', dims=(:x, :y))) == (9,6)
-    @test dimnames(cat(nda', r23', nda', dims=(1,2))) == (:y, :x)
-
-    @test dimnames(cat(1:2, ndv, [5 6]', dims=:z)) == (:x, :_, :z)
-
-    vcat(pi, ndv) # does not at present have names
-    vcat(ndv, pi)
-
+        vcat(pi, ndv) # does not at present have names
+        vcat(ndv, pi)
+    end
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -12,8 +12,8 @@
                   parent(cat(a, nda; dims=d)) ==
                   parent(cat(nda, nda; dims=d))
             @test cat(a, a, a; dims=d) ==
-                  parent(cat(a, nda, nda; dims=d)) == 
-                  parent(cat(nda, a, nda; dims=d)) == 
+                  parent(cat(a, nda, nda; dims=d)) ==
+                  parent(cat(nda, a, nda; dims=d)) ==
                   parent(cat(nda, nda, nda; dims=d))
         end
     end
@@ -94,4 +94,29 @@ for (f, d) in zip((vcat, hcat), (1, 2))
             @test dimnames(f(a, nda)) == dimnames(cat(a, nda; dims=d))
         end
     end
+end
+
+@testset "tricky cases" begin
+
+    r23 = rand(Int8, 2,3)
+    nda = NamedDimsArray(rand(2,3), (:x, :y))
+    ndv = NamedDimsArray(rand(2), (:x,))
+
+    @test dimnames(hcat(nda, ndv)) == (:x, :y)
+    @test dimnames(cat(nda, ndv, dims=2)) == (:x, :y)
+
+    @test dimnames(hcat(r23', nda', nda')) == (:y, :x)
+    @test dimnames(cat(r23', nda', nda', dims=2)) == (:y, :x)
+
+    @test_throws Exception hcat(nda, r23')
+    @test_throws Exception cat(nda, r23', dims=2)
+
+    @test size(cat(nda', r23', nda', dims=(:x, :y))) == (9,6)
+    @test dimnames(cat(nda', r23', nda', dims=(1,2))) == (:y, :x)
+
+    @test dimnames(cat(1:2, ndv, [5 6]', dims=:z)) == (:x, :_, :z)
+
+    vcat(pi, ndv) # does not at present have names
+    vcat(ndv, pi)
+
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -93,6 +93,21 @@ for (f, d) in zip((vcat, hcat), (1, 2))
             @test dimnames(f(nda, a)) == dimnames(cat(nda, a; dims=d))
             @test dimnames(f(a, nda)) == dimnames(cat(a, nda; dims=d))
         end
+
+        @testset "reduce forms" begin
+            @test reduce(f, [nda, nda]) == f(nda, nda)
+            @test reduce(f, [ndv, ndv]) == f(ndv, ndv)
+
+            v1 = NamedDimsArray([a, a], dimnames(nda, d))
+            v2 = NamedDimsArray([a, nda, a, nda], dimnames(nda, d))
+            @test dimnames(reduce(f, v1), d) == dimnames(nda, d)
+            @test dimnames(reduce(f, v2)) == dimnames(nda)
+
+            v3 = NamedDimsArray([a, nda', a], dimnames(nda, d)) # inner mismatch outer
+            @test_throws Exception reduce(f, v3)
+
+            @test_throws Exception reduce(f, [nda, nda']) # inconsistent inner names
+        end
     end
 end
 
@@ -114,6 +129,7 @@ end
 
         @test dimnames(hcat(nda, ndv)) == (:x, :y)
         @test dimnames(cat(nda, ndv, dims=2)) == (:x, :y)
+        @test dimnames(reduce(hcat, [nda, ndv])) == (:x, :y)
 
         @test dimnames(hcat(r23', nda', nda')) == (:y, :x)
         @test dimnames(cat(r23', nda', nda', dims=2)) == (:y, :x)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -94,6 +94,16 @@ for (f, d) in zip((vcat, hcat), (1, 2))
             @test dimnames(f(a, nda)) == dimnames(cat(a, nda; dims=d))
         end
     end
+    @testset "more than 2 dimensions" begin
+        ndt = NamedDimsArray(rand(Int8,2,2,2), (:x, :y, :z))
+
+        @test dimnames(hcat(ndt, ndt, parent(ndt))) == (:x, :y, :z)
+        @test dimnames(cat(ndt, ndt, parent(ndt), dims=:y)) == (:x, :y, :z)
+
+        @test_throws Exception hcat(ndt, parent(ndt), permutedims(ndt, (3,2,1)))
+        @test_throws Exception cat(ndt, parent(ndt), permutedims(ndt, (3,2,1)), dims=2)
+
+    end
 end
 
 @testset "tricky cases" begin

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -94,6 +94,9 @@ for (f, d) in zip((vcat, hcat), (1, 2))
             @test dimnames(f(a, nda)) == dimnames(cat(a, nda; dims=d))
         end
     end
+end
+
+@testset "more cats" begin
     @testset "more than 2 dimensions" begin
         ndt = NamedDimsArray(rand(Int8,2,2,2), (:x, :y, :z))
 


### PR DESCRIPTION
I was chasing ambiguities, and found the following bugs in the handling of `hcat` here: 
```julia
julia> using NamedDims

julia> nda = NamedDimsArray(rand(2,3), (:x, :y));

julia> ndv = NamedDimsArray(rand(2), (:x,));

julia> hcat(nda, ndv) # has lost a name
2×4 NamedDimsArray{(:x, :_), Float64, 2, Matrix{Float64}}:
 0.434524    0.73716   0.509066  0.309907
 0.00329738  0.669837  0.154734  0.405725

julia> hcat(nda, nda.data') # wrong sizes, but no error
2×6 NamedDimsArray{(:x, :y), Float64, 2, Matrix{Float64}}:
 0.434524    0.73716   0.509066  0.434524    0.73716   0.509066
 0.00329738  0.669837  0.154734  0.00329738  0.669837  0.154734
```
So I tried to fix them. Existing tests are untouched, and all pass. On the new testset, NamedDims v0.2.26 gives 2 passed, 4 failed, 3 errored, 0 broken.

I also replaced some `Array{T,N}` with `typeof(data)`, although I didn't make a test... I guess one could add SparseArrays or something. (Actually, I'm not sure there's any benefit to writing more than `NamedDimsArray{newL}(data)` each time.)

Edit -- this also broke `hcat` on 3-arrays, at first. Base routes these to `cat(As...; dims=Val(2))` so I made that work.