### PR TITLE
Run formatter (without typedef whitespace)

### DIFF
--- a/src/NamedDims.jl
+++ b/src/NamedDims.jl
@@ -15,7 +15,7 @@ function __init__()
 end
 
 # We use CoVector to workout if we are taking the tranpose of a tranpose etc
-const CoVector = Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:AbstractVector}}
+const CoVector = Union{Adjoint{<:Any,<:AbstractVector},Transpose{<:Any,<:AbstractVector}}
 
 include("name_core.jl")
 include("wrapper_array.jl")

--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -4,10 +4,10 @@ This is a `BroadcastStyle` for NamedDimsArray's
 It preserves the dimension names.
 `S` should be the `BroadcastStyle` of the wrapped type.
 """
-struct NamedDimsStyle{S <: BroadcastStyle} <: AbstractArrayStyle{Any} end
+struct NamedDimsStyle{S<:BroadcastStyle} <: AbstractArrayStyle{Any} end
 NamedDimsStyle(::S) where {S} = NamedDimsStyle{S}()
 NamedDimsStyle(::S, ::Val{N}) where {S,N} = NamedDimsStyle(S(Val(N)))
-NamedDimsStyle(::Val{N}) where N = NamedDimsStyle{DefaultArrayStyle{N}}()
+NamedDimsStyle(::Val{N}) where {N} = NamedDimsStyle{DefaultArrayStyle{N}}()
 function NamedDimsStyle(a::BroadcastStyle, b::BroadcastStyle)
     inner_style = BroadcastStyle(a, b)
 
@@ -18,18 +18,22 @@ function NamedDimsStyle(a::BroadcastStyle, b::BroadcastStyle)
         return NamedDimsStyle(inner_style)
     end
 end
-function Base.BroadcastStyle(::Type{<:NamedDimsArray{L, T, N, A}}) where {L, T, N, A}
+function Base.BroadcastStyle(::Type{<:NamedDimsArray{L,T,N,A}}) where {L,T,N,A}
     inner_style = typeof(BroadcastStyle(A))
     return NamedDimsStyle{inner_style}()
 end
 
-
-Base.BroadcastStyle(::NamedDimsStyle{A}, ::NamedDimsStyle{B}) where {A, B} = NamedDimsStyle(A(), B())
-Base.BroadcastStyle(::NamedDimsStyle{A}, b::B) where {A, B} = NamedDimsStyle(A(), b)
-Base.BroadcastStyle(a::A, ::NamedDimsStyle{B}) where {A, B} = NamedDimsStyle(a, B())
-Base.BroadcastStyle(::NamedDimsStyle{A}, b::DefaultArrayStyle) where {A} = NamedDimsStyle(A(), b)
-Base.BroadcastStyle(a::AbstractArrayStyle{M}, ::NamedDimsStyle{B}) where {B,M} = NamedDimsStyle(a, B())
-
+function Base.BroadcastStyle(::NamedDimsStyle{A}, ::NamedDimsStyle{B}) where {A,B}
+    return NamedDimsStyle(A(), B())
+end
+Base.BroadcastStyle(::NamedDimsStyle{A}, b::B) where {A,B} = NamedDimsStyle(A(), b)
+Base.BroadcastStyle(a::A, ::NamedDimsStyle{B}) where {A,B} = NamedDimsStyle(a, B())
+function Base.BroadcastStyle(::NamedDimsStyle{A}, b::DefaultArrayStyle) where {A}
+    return NamedDimsStyle(A(), b)
+end
+function Base.BroadcastStyle(a::AbstractArrayStyle{M}, ::NamedDimsStyle{B}) where {B,M}
+    return NamedDimsStyle(a, B())
+end
 
 """
     unwrap_broadcasted
@@ -38,17 +42,16 @@ Recursively unwraps `NamedDimsArray`s and `NamedDimsStyle`s.
 replacing the `NamedDimsArray`s with the wrapped array,
 and `NamedDimsStyle` with the wrapped `BroadcastStyle`.
 """
-function unwrap_broadcasted(bc::Broadcasted{NamedDimsStyle{S}}) where S
+function unwrap_broadcasted(bc::Broadcasted{NamedDimsStyle{S}}) where {S}
     inner_args = map(unwrap_broadcasted, bc.args)
     return Broadcasted{S}(bc.f, inner_args)
 end
 unwrap_broadcasted(x) = x
 unwrap_broadcasted(nda::NamedDimsArray) = parent(nda)
 
-
 # We need to implement copy because if the wrapper array type does not support setindex
 # then the `similar` based default method will not work
-function Broadcast.copy(bc::Broadcasted{NamedDimsStyle{S}}) where S
+function Broadcast.copy(bc::Broadcasted{NamedDimsStyle{S}}) where {S}
     inner_bc = unwrap_broadcasted(bc)
     data = copy(inner_bc)
 
@@ -56,7 +59,7 @@ function Broadcast.copy(bc::Broadcasted{NamedDimsStyle{S}}) where S
     return NamedDimsArray{L}(data)
 end
 
-function Base.copyto!(dest::AbstractArray, bc::Broadcasted{NamedDimsStyle{S}}) where S
+function Base.copyto!(dest::AbstractArray, bc::Broadcasted{NamedDimsStyle{S}}) where {S}
     inner_bc = unwrap_broadcasted(bc)
     copyto!(dest, inner_bc)
     L = unify_names(dimnames(dest), broadcasted_names(bc))
@@ -67,7 +70,7 @@ broadcasted_names(bc::Broadcasted) = broadcasted_names(bc.args...)
 function broadcasted_names(a, bs...)
     a_name = broadcasted_names(a)
     b_name = broadcasted_names(bs...)
-    unify_names_longest(a_name, b_name)
+    return unify_names_longest(a_name, b_name)
 end
 broadcasted_names(a::AbstractArray) = dimnames(a)
 broadcasted_names(a) = tuple()

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -30,9 +30,7 @@ for (mod, funs) in (
 end
 
 # 1 Arg - no default for `dims` keyword
-for (mod, funs) in (
-    (:Base, (:cumsum, :cumprod, :sort, :sort!, :sortslices)),
-)
+for (mod, funs) in ((:Base, (:cumsum, :cumprod, :sort, :sort!, :sortslices)),)
     for fun in funs
         @eval function $mod.$fun(a::NamedDimsArray; dims, kwargs...)
             numerical_dims = dim(a, dims)
@@ -41,7 +39,7 @@ for (mod, funs) in (
         end
 
         # Vector case
-        @eval function $mod.$fun(a::NamedDimsArray{L, T, 1}; kwargs...) where {L, T}
+        @eval function $mod.$fun(a::NamedDimsArray{L,T,1}; kwargs...) where {L,T}
             data = $mod.$fun(parent(a); kwargs...)
             return NamedDimsArray{dimnames(a)}(data)
         end
@@ -49,7 +47,7 @@ for (mod, funs) in (
 end
 
 if VERSION > v"1.1-"
-    function Base.eachslice(a::NamedDimsArray{L}; dims, kwargs...) where L
+    function Base.eachslice(a::NamedDimsArray{L}; dims, kwargs...) where {L}
         numerical_dims = dim(a, dims)
         slices = eachslice(parent(a); dims=numerical_dims, kwargs...)
         return Base.Generator(slices) do slice
@@ -62,9 +60,7 @@ if VERSION > v"1.1-"
 end
 
 # 1 arg before - no default for `dims` keyword
-for (mod, funs) in (
-    (:Base, (:mapslices,)),
-)
+for (mod, funs) in ((:Base, (:mapslices,)),)
     for fun in funs
         @eval function $mod.$fun(f, a::NamedDimsArray; dims, kwargs...)
             numerical_dims = dim(a, dims)
@@ -75,9 +71,7 @@ for (mod, funs) in (
 end
 
 # 2 arg before
-for (mod, funs) in (
-    (:Base, (:mapreduce,)),
-)
+for (mod, funs) in ((:Base, (:mapreduce,)),)
     for fun in funs
         @eval function $mod.$fun(f1, f2, a::NamedDimsArray; dims=:, kwargs...)
             numerical_dims = dim(a, dims)
@@ -91,18 +85,18 @@ end
 # Non-dim Overloads
 
 for fun in (:(==), :isequal, :isapprox)
-    @eval function Base.$fun(a::NamedDimsArray{La}, b::NamedDimsArray{Lb}; kw...) where {La, Lb}
+    @eval function Base.$fun(
+        a::NamedDimsArray{La}, b::NamedDimsArray{Lb}; kw...,
+    ) where {La,Lb}
         names_are_unifiable(La, Lb) || return false
         return $fun(parent(a), parent(b); kw...)
     end
 end
 
 # Array then perhaps other args
-for (mod, funs) in (
-    (:Base, (:zero, :one, :copy, :empty!, :push!, :pushfirst!)),
-)
+for (mod, funs) in ((:Base, (:zero, :one, :copy, :empty!, :push!, :pushfirst!)),)
     for fun in funs
-        @eval function $mod.$fun(a::NamedDimsArray{L}, x...) where L
+        @eval function $mod.$fun(a::NamedDimsArray{L}, x...) where {L}
             data = $mod.$fun(parent(a), x...)
             return NamedDimsArray{L}(data)
         end
@@ -110,24 +104,22 @@ for (mod, funs) in (
 end
 
 # Two arrays
-for (mod, funs) in (
-    (:Base, (:sum!, :prod!, :maximum!, :minimum!)),
-)
+for (mod, funs) in ((:Base, (:sum!, :prod!, :maximum!, :minimum!)),)
     for fun in funs
         @eval begin
 
-            function $mod.$fun(a::NamedDimsArray{L}, b::AbstractArray) where L
+            function $mod.$fun(a::NamedDimsArray{L}, b::AbstractArray) where {L}
                 data = $mod.$fun(parent(a), b)
                 return NamedDimsArray{L}(data)
             end
 
-            function $mod.$fun(a::AbstractArray, b::NamedDimsArray{L}) where L
+            function $mod.$fun(a::AbstractArray, b::NamedDimsArray{L}) where {L}
                 data = $mod.$fun(a, parent(b))
                 newL = unify_names_shortest(L, ntuple(_ -> :_, ndims(a)))
                 return NamedDimsArray{newL}(data)
             end
 
-            function $mod.$fun(a::NamedDimsArray{La}, b::NamedDimsArray{Lb}) where {La, Lb}
+            function $mod.$fun(a::NamedDimsArray{La}, b::NamedDimsArray{Lb}) where {La,Lb}
                 newL = unify_names_shortest(La, Lb)
                 data = $mod.$fun(parent(a), parent(b))
                 return NamedDimsArray{newL}(data)
@@ -155,7 +147,7 @@ for (T, S) in [
     (:NamedDimsArray, :AbstractArray),
     (:AbstractArray, :NamedDimsArray),
     (:NamedDimsArray, :NamedDimsArray),
-    ]
+]
     for fun in [:map, :map!]
 
         # Here f::F where {F} is needed to avoid ambiguities in Julia 1.0
@@ -174,9 +166,10 @@ for (T, S) in [
     end
 end
 
-Base.filter(f, A::NamedDimsArray{L,T,1}) where {L,T} = NamedDimsArray(filter(f, parent(A)), L)
+function Base.filter(f, A::NamedDimsArray{L,T,1}) where {L,T}
+    return NamedDimsArray(filter(f, parent(A)), L)
+end
 Base.filter(f, A::NamedDimsArray{L,T,N}) where {L,T,N} = filter(f, parent(A))
-
 
 # We overload collect on various kinds of `Generators` so that that can keep names.
 function Base.collect(x::Base.Generator{<:NamedDimsArray{L}}) where {L}
@@ -184,14 +177,32 @@ function Base.collect(x::Base.Generator{<:NamedDimsArray{L}}) where {L}
     return NamedDimsArray(data, L)
 end
 
-function Base.collect(x::Base.Generator{<:Iterators.Enumerate{<:NamedDimsArray{L}}}) where {L}
+function Base.collect(
+    x::Base.Generator{<:Iterators.Enumerate{<:NamedDimsArray{L}}},
+) where {L}
     data = collect(Base.Generator(x.f, enumerate(parent(x.iter.itr))))
     return NamedDimsArray(data, L)
 end
 
-Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{<:NamedDimsArray,Vararg{Any}}}}) = collect_product(x)
-Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{<:Any,<:NamedDimsArray,Vararg{Any}}}}) = collect_product(x)
-Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{<:NamedDimsArray,<:NamedDimsArray,Vararg{Any}}}}) = collect_product(x)
+function Base.collect(
+    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{<:NamedDimsArray,Vararg{Any}}}},
+)
+    return collect_product(x)
+end
+function Base.collect(
+    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{
+        <:Any,<:NamedDimsArray,Vararg{Any},
+    }}},
+)
+    return collect_product(x)
+end
+function Base.collect(
+    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{
+        <:NamedDimsArray,<:NamedDimsArray,Vararg{Any},
+    }}},
+)
+    return collect_product(x)
+end
 
 function collect_product(x)
     data = collect(Base.Generator(x.f, Iterators.product(unname.(x.iter.iterators)...)))

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -189,7 +189,7 @@ for Tup in (
     Tuple{<:Any,<:NamedDimsArray,Vararg{Any}},
     Tuple{<:NamedDimsArray,<:NamedDimsArray,Vararg{Any}},
 )
-    @eval function Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:Tup}})
+    @eval function Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:$Tup}})
         return collect_product(x)
     end
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -184,24 +184,14 @@ function Base.collect(
     return NamedDimsArray(data, L)
 end
 
-function Base.collect(
-    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{<:NamedDimsArray,Vararg{Any}}}},
+for Tup in (
+    Tuple{<:NamedDimsArray,Vararg{Any}},
+    Tuple{<:Any,<:NamedDimsArray,Vararg{Any}},
+    Tuple{<:NamedDimsArray,<:NamedDimsArray,Vararg{Any}},
 )
-    return collect_product(x)
-end
-function Base.collect(
-    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{
-        <:Any,<:NamedDimsArray,Vararg{Any},
-    }}},
-)
-    return collect_product(x)
-end
-function Base.collect(
-    x::Base.Generator{<:Iterators.ProductIterator{<:Tuple{
-        <:NamedDimsArray,<:NamedDimsArray,Vararg{Any},
-    }}},
-)
-    return collect_product(x)
+    @eval function Base.collect(x::Base.Generator{<:Iterators.ProductIterator{<:Tup}})
+        return collect_product(x)
+    end
 end
 
 function collect_product(x)

--- a/src/functions_dims.jl
+++ b/src/functions_dims.jl
@@ -18,13 +18,8 @@ function Base.selectdim(nda::NamedDimsArray, s::Symbol, i)
     return selectdim(nda, dim(nda, s), i)
 end
 
-for f in (
-    :(Base.transpose),
-    :(Base.adjoint),
-    :(Base.permutedims),
-    :(LinearAlgebra.pinv)
-)
-    @eval function $f(nda::NamedDimsArray{L}) where (L)
+for f in (:(Base.transpose), :(Base.adjoint), :(Base.permutedims), :(LinearAlgebra.pinv))
+    @eval function $f(nda::NamedDimsArray{L}) where {(L)}
         data = $f(parent(nda))
         new_names = if ndims(nda) == 1 # vector input
             (:_, first(L))
@@ -39,4 +34,4 @@ end
 
 # reshape
 # For now we only implement the version that drops dimension names
-Base.reshape(x::NamedDimsArray, d::Vararg{Union{Colon, Int}}) = reshape(parent(x), d)
+Base.reshape(x::NamedDimsArray, d::Vararg{Union{Colon,Int}}) = reshape(parent(x), d)

--- a/src/functions_math.jl
+++ b/src/functions_math.jl
@@ -2,7 +2,7 @@
 
 # Matrix product
 valid_matmul_dims(a::Tuple{Symbol}, b::Tuple{Vararg{Symbol}}) = true
-function valid_matmul_dims(a::Tuple{Symbol, Symbol}, b::Tuple{Vararg{Symbol}})
+function valid_matmul_dims(a::Tuple{Symbol,Symbol}, b::Tuple{Vararg{Symbol}})
     a_dim = a[end]
     b_dim = b[1]
 
@@ -11,7 +11,7 @@ end
 
 matmul_names((a1, a2)::Tuple{Symbol,Symbol}, (b,)::Tuple{Symbol}) = (a1,)
 matmul_names((a1, a2)::Tuple{Symbol,Symbol}, (b1, b2)::Tuple{Symbol,Symbol}) = (a1, b2)
-matmul_names((a1,)::Tuple{Symbol,},(b1,b2)::Tuple{Symbol,Symbol}) = (a1, b2)
+matmul_names((a1,)::Tuple{Symbol}, (b1, b2)::Tuple{Symbol,Symbol}) = (a1, b2)
 
 function throw_matrix_dim_error(a, b)
     msg = "Cannot take matrix product of arrays with different inner dimension names. $a vs $b"
@@ -25,16 +25,20 @@ function matrix_prod_names(a, b)
     return compile_time_return_hack(res)
 end
 
-for (NA, NB) in ((1,2), (2,1), (2,2))  #Vector * Vector, is not allowed
-    @eval function Base.:*(a::NamedDimsArray{A,T,$NA}, b::NamedDimsArray{B,S,$NB}) where {A,B,T,S}
-        L = matrix_prod_names(A,B)
+for (NA, NB) in ((1, 2), (2, 1), (2, 2))  #Vector * Vector, is not allowed
+    @eval function Base.:*(
+        a::NamedDimsArray{A,T,$NA}, b::NamedDimsArray{B,S,$NB},
+    ) where {A,B,T,S}
+        L = matrix_prod_names(A, B)
         data = *(parent(a), parent(b))
         return NamedDimsArray{L}(data)
     end
 end
 
 # vector^T * vector
-function Base.:*(a::NamedDimsArray{A,T,2,<:CoVector}, b::NamedDimsArray{B,S,1}) where {A,B,T,S}
+function Base.:*(
+    a::NamedDimsArray{A,T,2,<:CoVector}, b::NamedDimsArray{B,S,1},
+) where {A,B,T,S}
     valid_matmul_dims(A, B) || throw_matrix_dim_error(last(A), first(B))
     return *(parent(a), parent(b))
 end
@@ -44,7 +48,7 @@ function Base.:*(a::NamedDimsArray{L,T,2,<:CoVector}, b::AbstractVector) where {
 end
 
 # Using `CoVector` results in Method ambiguities; have to define more specific methods.
-for A in (Adjoint{<:Number, <:AbstractVector}, Transpose{<:Real, <:AbstractVector{<:Real}})
+for A in (Adjoint{<:Number,<:AbstractVector}, Transpose{<:Real,<:AbstractVector{<:Real}})
     @eval function Base.:*(a::$A, b::NamedDimsArray{L,T,1,<:AbstractVector{T}}) where {L,T}
         return *(a, parent(b))
     end
@@ -59,10 +63,10 @@ It defines the various overloads for `Base.:*` that are required.
 It should be used at the top level of a module.
 """
 macro declare_matmul(MatrixT, VectorT=nothing)
-    dim_combos = VectorT === nothing ? ((2,2),) : ((1,2), (2,1), (2,2))
+    dim_combos = VectorT === nothing ? ((2, 2),) : ((1, 2), (2, 1), (2, 2))
     codes = map(dim_combos) do (NA, NB)
-        TA_named = :(NamedDims.NamedDimsArray{<:Any, <:Any, $NA})
-        TB_named = :(NamedDims.NamedDimsArray{<:Any, <:Any, $NB})
+        TA_named = :(NamedDims.NamedDimsArray{<:Any,<:Any,$NA})
+        TB_named = :(NamedDims.NamedDimsArray{<:Any,<:Any,$NB})
         TA_other = (VectorT, MatrixT)[NA]
         TB_other = (VectorT, MatrixT)[NB]
 
@@ -82,19 +86,21 @@ end
 # @declare_matmul(Diagonal, AbstractVector)
 # but that overwrites existing *(1D NDA, Vector) methods
 # should improve the macro above to deal with this case
-function Base.:*(a::Diagonal, b::NamedDimsArray{<:Any, <:Any, 1})
+function Base.:*(a::Diagonal, b::NamedDimsArray{<:Any,<:Any,1})
     return *(NamedDimsArray{dimnames(a)}(a), b)
 end
 
-function Base.:*(a::NamedDimsArray{<:Any, <:Any, 1}, b::Diagonal)
+function Base.:*(a::NamedDimsArray{<:Any,<:Any,1}, b::Diagonal)
     return *(a, NamedDimsArray{dimnames(b)}(b))
 end
 
 @declare_matmul(AbstractMatrix, AbstractVector)
-@declare_matmul(Adjoint{<:Any, <:AbstractMatrix{T1}} where T1, Adjoint{<:Any, <:AbstractVector})
+@declare_matmul(
+    Adjoint{<:Any,<:AbstractMatrix{T1}} where {T1}, Adjoint{<:Any,<:AbstractVector}
+)
 @declare_matmul(Diagonal,)
 
-function Base.inv(nda::NamedDimsArray{L, T, 2}) where {L,T}
+function Base.inv(nda::NamedDimsArray{L,T,2}) where {L,T}
     data = inv(parent(nda))
     names = reverse(L)
     return NamedDimsArray{names}(data)
@@ -102,7 +108,7 @@ end
 
 # Statistics
 for fun in (:cor, :cov)
-    @eval function Statistics.$fun(a::NamedDimsArray{L, T, 2}; dims=1, kwargs...) where {L, T}
+    @eval function Statistics.$fun(a::NamedDimsArray{L,T,2}; dims=1, kwargs...) where {L,T}
         numerical_dims = dim(a, dims)
         data = Statistics.$fun(parent(a); dims=numerical_dims, kwargs...)
         names = symmetric_names(L, numerical_dims)

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -308,8 +308,11 @@ function unify_names_shortest(names_a, names_b)
     # 0 Allocations: @btime (()-> unify_names_shortest((:a,:b), (:a,)))()
 
     length(names_a) === length(names_b) && return unify_names(names_a, names_b)
-    long, short =
-        length(names_a) > length(names_b) ? (names_a, names_b) : (names_b, names_a)
+    long, short = if length(names_a) > length(names_b)
+        (names_a, names_b)
+    else
+        (names_b, names_a)
+    end
     ret = ntuple(length(short)) do ii
         a = getfield(long, ii)
         b = getfield(short, ii)

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -13,7 +13,7 @@ with the old names (though you do still need to match the number of dimensions).
 """
 rename(nda::NamedDimsArray, names) = NamedDimsArray(parent(nda), names)
 
-function rename(nda::NamedDimsArray, pairs::Vararg{Pair{Symbol, Symbol}})
+function rename(nda::NamedDimsArray, pairs::Vararg{Pair{Symbol,Symbol}})
     names = dimnames(nda)
     new_names = ntuple(i -> _rename(names[i], pairs...), length(names))
     return NamedDimsArray(parent(nda), new_names)
@@ -56,8 +56,8 @@ Gives wildcards `:_` if this is not a `NamedDimsArray`.
 Like `size(A, d)`, it allows `d > ndims(A)`, in this case all the trailing dimension are given the wildcard name (`:_`).
 """
 dimnames(::Type{<:NamedDimsArray{L}}) where {L} = L
-dimnames(::Type{<:AbstractArray{T, N}}) where {T, N} = ntuple(_->:_, N)
-dimnames(x::T) where T<:AbstractArray = dimnames(T)
+dimnames(::Type{<:AbstractArray{T,N}}) where {T,N} = ntuple(_ -> :_, N)
+dimnames(x::T) where {T<:AbstractArray} = dimnames(T)
 
 function dimnames(AT::Type{<:AbstractArray{T,N}}, d::Integer) where {T,N}
     if 1 <= d <= N
@@ -68,4 +68,4 @@ function dimnames(AT::Type{<:AbstractArray{T,N}}, d::Integer) where {T,N}
         throw(DimensionMismatch("dimnames: dimension out of range"))
     end
 end
-dimnames(x::T, d::Integer) where T<:AbstractArray = dimnames(T, d)
+dimnames(x::T, d::Integer) where {T<:AbstractArray} = dimnames(T, d)

--- a/src/tracker_compat.jl
+++ b/src/tracker_compat.jl
@@ -9,17 +9,21 @@ Tracker.TrackedArray(::Tracker.Call, ::NamedDimsArray, ::AbstractArray) = error(
 Tracker.TrackedArray(::Tracker.Call, ::AbstractArray, ::NamedDimsArray) = error("Should not make Tracked NamedDimsArray")
 ==#
 
-Base.BroadcastStyle(::NamedDimsStyle{A}, b::Tracker.TrackedStyle) where {A} = NamedDimsStyle(A(), b)
-Base.BroadcastStyle(a::Tracker.TrackedStyle, ::NamedDimsStyle{B}) where {B} = NamedDimsStyle(a, B())
+function Base.BroadcastStyle(::NamedDimsStyle{A}, b::Tracker.TrackedStyle) where {A}
+    return NamedDimsStyle(A(), b)
+end
+function Base.BroadcastStyle(a::Tracker.TrackedStyle, ::NamedDimsStyle{B}) where {B}
+    return NamedDimsStyle(a, B())
+end
 
 @declare_matmul(Tracker.TrackedMatrix, Tracker.TrackedVector)
 
-function Tracker.data(nda::NamedDimsArray{L}) where L
+function Tracker.data(nda::NamedDimsArray{L}) where {L}
     content = Tracker.data(parent(nda))
     return NamedDimsArray{L}(content)
 end
 
-function Tracker.track(c::Tracker.Call, nda::NamedDimsArray{L}) where L
+function Tracker.track(c::Tracker.Call, nda::NamedDimsArray{L}) where {L}
     content = Tracker.track(c, parent(nda))
     return NamedDimsArray{L}(content)
 end


### PR DESCRIPTION
Same as #137 but with `whitespace_typedefs=false` (i.e. Run JuliaFormatter as a way to test out domluna/JuliaFormatter.jl#295)

```julia
julia> format(
                  "src/"; 
                  style=BlueStyle(),  # requires JuliaFormatter v0.8.2 https://github.com/domluna/JuliaFormatter.jl.git#bluestyle-1
                  always_use_return=true,
                  short_to_long_function_def=true,
                  whitespace_ops_in_indices=true,
                  remove_extra_newlines=true,
                  always_for_in=true,
                  import_to_using=true,
                  pipe_to_function_call=true,
                  whitespace_in_kwargs=false,
                  whitespace_typedefs=false,
         )
```
(fyi it's also possible to tell some bits to not be formatted https://domluna.github.io/JuliaFormatter.jl/stable/skipping_formatting/)