### PR TITLE
make unname accept anything, and dim accept AbstractArray + number (Close #136)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.28"
+version = "0.2.29"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/name_operations.jl
+++ b/src/name_operations.jl
@@ -35,22 +35,22 @@ end
 
 """
     unname(A::NamedDimsArray) -> AbstractArray
-    unname(A::AbstractArray) -> AbstractArray
+    unname(A) === A
 
 Return the input array `A` without any dimension names.
 
 For `NamedDimsArray`s this returns the parent array, equivalent to calling `parent`, but for
-any other `AbstractArray` simply returns the input.
+anything else it simply returns the input.
 """
 unname(x::NamedDimsArray) = parent(x)
-unname(x::AbstractArray) = x
+unname(x) = x
 
 """
     dimnames(A) -> Tuple
     dimnames(A, d) -> Symbol
 
-Return the names of all the dimensions of the array `A`, 
-or just the one for the `d`-th dimension. 
+Return the names of all the dimensions of the array `A`,
+or just the one for the `d`-th dimension.
 
 Gives wildcards `:_` if this is not a `NamedDimsArray`.
 Like `size(A, d)`, it allows `d > ndims(A)`, in this case all the trailing dimension are given the wildcard name (`:_`).

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -57,6 +57,7 @@ parent_type(::Type{<:NamedDimsArray{L,T,N,A}}) where {L,T,N,A} = A
 Base.parent(x::NamedDimsArray) = getfield(x, :data)
 
 dim(a::NamedDimsArray{L}, name) where {L} = dim(L, name)
+dim(a::AbstractArray, d) = d
 
 NamedDimsVecOrMat{L,T} = Union{NamedDimsArray{L,T,1},NamedDimsArray{L,T,2}}
 NamedDimsVector{L,T} = NamedDimsArray{L,T,1}

--- a/test/name_operations.jl
+++ b/test/name_operations.jl
@@ -3,10 +3,11 @@
         @test unname(NamedDimsArray(orig, (:x, :y))) === orig
         @test unname(orig) === orig
     end
+    @test unname((1,2,3)) === (1,2,3)
 end
 
 
-@testset "dimnames" begin   
+@testset "dimnames" begin
     nda = NamedDimsArray([10 20; 30 40], (:x, :y))
 
     @test dimnames(nda) === (:x, :y)
@@ -16,7 +17,7 @@ end
     @test dimnames([10 20; 30 40]) === (:_, :_)
     @test dimnames([10 20; 30 40], 2) === :_
     @test dimnames([10 20; 30 40], 3) === :_
-    
+
     v = NamedDimsArray(1:2, :a)
     @test dimnames(v, 2) == dimnames(permutedims(v), 1) # That's why :_ for d > ndims
 

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -1,5 +1,4 @@
 using NamedDims
-using NamedDims: names
 using SparseArrays
 using Test
 
@@ -7,12 +6,19 @@ using Test
 @testset "get the parent array that was wrapped" begin
     for orig in ([1 2; 3 4], spzeros(2, 2))
         @test parent(NamedDimsArray(orig, (:x, :y))) === orig
-
         @test unname(NamedDimsArray(orig, (:x, :y))) === orig
         @test unname(orig) === orig
     end
 end
 
+@testset "function dim(array, dim)" begin
+    nda = NamedDimsArray([10 20; 30 40], (:x, :y))
+    @test dim(nda, :x) == 1
+    @test dim(nda, [:y, :x]) == [2, 1]
+    @test dim(nda, 2) == 2
+    @test dim(parent(nda), 2) == 2
+    @test_throws ArgumentError dim(nda, :nope)
+end
 
 @testset "get the named array that was wrapped" begin
     @test dimnames(NamedDimsArray([10 20; 30 40], (:x, :y))) === (:x, :y)


### PR DESCRIPTION
This allows `numerical_dims = dim(A, dims)` to work for any array, by doing nothing when `A` doesn't have names. This closes #136.

It also allows `unname(A)` to accept anything, so that `map(unname, args)` can strip all dimension names without first checking which arguments are are arrays. 