### PR TITLE
Fix a `vcat` ambiguity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.29"
+version = "0.2.30"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -43,6 +43,18 @@ for (T, S) in [
     end
 end
 
+for (T, S) in [
+    (:NamedDimsVector, :NamedDimsVector),
+    (:NamedDimsVector, :AbstractVector),
+    (:AbstractVector, :NamedDimsVector),
+]
+    @eval function Base.vcat(a::$T, b::$S, cs::AbstractVector...)
+        newL = unify_names(dimnames(a), dimnames(b), dimnames.(cs)...)
+        data = vcat(unname(a), unname(b), unname.(cs)...)
+        return NamedDimsArray{newL}(data)
+    end
+end
+
 for (f, nf, tf, tup) in
     [(:vcat, :_named_vcat, :_typed_vcat, ()), (:hcat, :_named_hcat, :_typed_hcat, (:_,))]
     @eval begin

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -142,6 +142,8 @@ end
 
         @test dimnames(cat(1:2, ndv, [5 6]', dims=:z)) == (:x, :_, :z)
 
+        @test dimnames(vcat(1:3, NamedDimsArray(4:6, :x))) == (:x,)
+
         vcat(pi, ndv) # does not at present have names
         vcat(ndv, pi)
     end


### PR DESCRIPTION
```
julia> vcat(1:3, NamedDimsArray(4:6, :x))
ERROR: MethodError: vcat(::UnitRange{Int64}, ::NamedDimsArray{(:x,), Int64, 1, UnitRange{Int64}}) is ambiguous. Candidates:
  vcat(V::AbstractVector{T}...) where T in Base at abstractarray.jl:1477
  vcat(V::AbstractVector{T} where T...) in Base at abstractarray.jl:1476
  vcat(a::AbstractVecOrMat{T} where T, b::Union{NamedDimsArray{L, T, 1, A} where A<:AbstractVector{T}, NamedDimsArray{L, T, 2, A} where A<:AbstractMatrix{T}} where T where L, cs::AbstractVecOrMat{T} where T...) in NamedDims at /Users/me/.julia/packages/NamedDims/ty09T/src/cat.jl:37
Possible fix, define
  vcat(::AbstractVector{T}, ::NamedDimsArray{L, T, 1, A} where A<:AbstractVector{T} where L, ::Vararg{AbstractVector{T}, N} where N) where T
```
So I did.