### PR TITLE
stop testing on 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"  # Would test on 1.0, but that causes trouble at test time as test can't downgrade main deps in 1.0
+          - "1.3"  # Would test on 1.0 (LTS), but that causes trouble at test time as test can't downgrade main deps in 1.0
           - "1"    # Latest Release
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
+          - "1.3"  # Would test on 1.0, but that causes trouble at test time as test can't downgrade main deps in 1.0
           - "1"    # Latest Release
         os:
           - ubuntu-latest


### PR DESCRIPTION
This will unblock #167 

Pkg for 1.0 doesn't do tiered  resolution.
I.e. it can't do the thing where it downgrades main dependency in order to install test dependencies

We do want to keep supporting 1.0 in principle, but it's not really viable to test through CI. 😞 