### PR TITLE
Use `axes` instead of `size` within `similar`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,10 @@ julia = "1"
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["BenchmarkTools", "FFTW", "SparseArrays", "Test", "Tracker"]
+test = ["BenchmarkTools", "FFTW", "OffsetArrays", "SparseArrays", "Test", "Tracker"]

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -82,25 +82,25 @@ function named_size(a::AbstractArray{T,N}) where {T,N}
     L = dimnames(a)
     return NamedTuple{L,NTuple{N,Int}}(size(a))
 end
-function Base.similar(a::NamedDimsArray{L,T}, eltype::Type=T) where {L,T}
+function Base.similar(a::NamedDimsArray{L,T}, ::Type{eltype}=T) where {L,T,eltype}
     dnames = dimnames(a)
     return NamedDimsArray(similar(parent(a), eltype), dnames)
 end
-function Base.similar(a::NamedDimsArray, eltype::Type, dims::NamedTuple)
+function Base.similar(a::NamedDimsArray, ::Type{eltype}, dims::NamedTuple) where eltype
     new_sizes = values(dims)
     new_names = keys(dims)
     return NamedDimsArray{new_names}(similar(parent(a), eltype, new_sizes))
 end
 function Base.similar(
-    a::NamedDimsArray{L,T,N}, eltype::Type, new_names::NTuple{N,Symbol},
-) where {T,N,L}
+    a::NamedDimsArray{L,T,N}, ::Type{eltype}, new_names::NTuple{N,Symbol},
+) where {L,T,N,eltype}
     dims = NamedTuple{new_names,NTuple{N,Int}}(size(a))
     return similar(a, eltype, dims)
 end
 
 function Base.similar(
-    a::NamedDimsArray{L,T,N}, eltype::Type, new_sizes::NTuple{N,Int},
-) where {L,T,N}
+    a::NamedDimsArray{L,T,N}, ::Type{eltype}, new_sizes::NTuple{N,Int},
+) where {L,T,N,eltype}
 
     dims = NamedTuple{L,NTuple{N,Int}}(new_sizes)
     return similar(a, eltype, dims)

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -80,7 +80,8 @@ Base.axes(a::NamedDimsArray, d) = axes(parent(a), dim(a, d))
 
 function named_size(a::AbstractArray{T,N}) where {T,N}
     L = dimnames(a)
-    return NamedTuple{L,NTuple{N,Int}}(size(a))
+    axes_a = axes(a)
+    return NamedTuple{L,typeof(axes_a)}(axes_a)
 end
 function Base.similar(
     a::NamedDimsArray{L,T}, eltype::Type=T, dims::NamedTuple{new_names}=named_size(a),

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -80,8 +80,15 @@ Base.axes(a::NamedDimsArray, d) = axes(parent(a), dim(a, d))
 
 function named_size(a::AbstractArray{T,N}) where {T,N}
     L = dimnames(a)
-    axes_a = axes(a)
-    return NamedTuple{L,typeof(axes_a)}(axes_a)
+    return NamedTuple{L,NTuple{N,Int}}(size(a))
+end
+function Base.similar(a::NamedDimsArray)
+    dnames = dimnames(a)
+    return NamedDimsArray(similar(parent(a)), dnames)
+end
+function Base.similar(a::NamedDimsArray{L,T}, eltype::Type=T) where {L,T}
+    dnames = dimnames(a)
+    return NamedDimsArray(similar(parent(a), eltype), dnames)
 end
 function Base.similar(
     a::NamedDimsArray{L,T}, eltype::Type=T, dims::NamedTuple{new_names}=named_size(a),

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -82,22 +82,15 @@ function named_size(a::AbstractArray{T,N}) where {T,N}
     L = dimnames(a)
     return NamedTuple{L,NTuple{N,Int}}(size(a))
 end
-function Base.similar(a::NamedDimsArray)
-    dnames = dimnames(a)
-    return NamedDimsArray(similar(parent(a)), dnames)
-end
 function Base.similar(a::NamedDimsArray{L,T}, eltype::Type=T) where {L,T}
     dnames = dimnames(a)
     return NamedDimsArray(similar(parent(a), eltype), dnames)
 end
-function Base.similar(
-    a::NamedDimsArray{L,T}, eltype::Type=T, dims::NamedTuple{new_names}=named_size(a),
-) where {L,T,new_names}
-
+function Base.similar(a::NamedDimsArray, eltype::Type, dims::NamedTuple)
     new_sizes = values(dims)
+    new_names = keys(dims)
     return NamedDimsArray{new_names}(similar(parent(a), eltype, new_sizes))
 end
-
 function Base.similar(
     a::NamedDimsArray{L,T,N}, eltype::Type, new_names::NTuple{N,Symbol},
 ) where {T,N,L}

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -269,6 +269,11 @@ end
         @test parent(ndd) isa OffsetArray
         @test eltype(parent(ndd)) == Float64
     end
+    @testset "repeated names" begin
+        ndr = NamedDimsArray([1 2; 3 4], (:same, :same))
+        @test dimnames(similar(ndr)) == (:same, :same)
+        @test dimnames(similar(ndr, Float64)) == (:same, :same)
+    end
 end
 
 @testset "Strided Array Interface" begin

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -260,14 +260,14 @@ end
         oa = OffsetArray(ones(10,20,30,40), -5:4, -10:9, -15:14, -20:19)
         ndb = NamedDimsArray(oa, (:a, :b, :c, :d))
         ndc = similar(ndb)
-        ndd = similar(ndb, Float64)
+        ndd = similar(ndb, Int)
         @test parent(ndb) !== parent(ndc)
         @test eltype(ndc) == Float64
         @test size(ndc) == (10, 20, 30, 40)
         @test dimnames(ndc) == (:a, :b, :c, :d)
         @test parent(ndc) isa typeof(oa)
         @test parent(ndd) isa OffsetArray
-        @test eltype(parent(ndd)) == Float64
+        @test eltype(parent(ndd)) == Int
     end
     @testset "repeated names" begin
         ndr = NamedDimsArray([1 2; 3 4], (:same, :same))

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -1,4 +1,5 @@
 using NamedDims
+using OffsetArrays
 using SparseArrays
 using Test
 
@@ -254,6 +255,16 @@ end
         @test eltype(ndb) == Float64
         @test size(ndb) == (11, 22)
         @test dimnames(ndb) == (:w, :x)
+    end
+    @testset "offset array" begin
+        oa = OffsetArray(ones(10,20,30,40), -5:4, -10:9, -15:14, -20:19)
+        ndb = NamedDimsArray(oa, (:a, :b, :c, :d))
+        ndc = similar(ndb)
+        @test parent(ndb) !== parent(ndc)
+        @test eltype(ndc) == Float64
+        @test size(ndc) == (10, 20, 30, 40)
+        @test dimnames(ndc) == (:a, :b, :c, :d)
+        @test parent(ndc) isa typeof(oa)
     end
 end
 

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -256,15 +256,18 @@ end
         @test size(ndb) == (11, 22)
         @test dimnames(ndb) == (:w, :x)
     end
-    @testset "offset array" begin
+    @testset "parent type" begin
         oa = OffsetArray(ones(10,20,30,40), -5:4, -10:9, -15:14, -20:19)
         ndb = NamedDimsArray(oa, (:a, :b, :c, :d))
         ndc = similar(ndb)
+        ndd = similar(ndb, Float64)
         @test parent(ndb) !== parent(ndc)
         @test eltype(ndc) == Float64
         @test size(ndc) == (10, 20, 30, 40)
         @test dimnames(ndc) == (:a, :b, :c, :d)
         @test parent(ndc) isa typeof(oa)
+        @test parent(ndd) isa OffsetArray
+        @test eltype(parent(ndd)) == Float64
     end
 end
 


### PR DESCRIPTION
When using an `OffsetArray` for the parent array inside of a `NamedDimsArray`, calling `similar` converts the parent array to a regular dense `Array`

```
using NamedDims
using OffsetArrays

oa = OffsetArray([1,2,3], -1:1)
nda = NamedDimsArray(oa, (:x,))
parent(similar(nda)) isa OffsetArray # false
parent(similar(nda)) isa Array # true
```

This is fixed by changing `size(A)` into `axes(A)` within `named_size`. `named_size` is called to determine the length of every dimension and attach this length to its corresponding dimension name. However, when we use an `OffsetArray`, the length is not sufficient to reconstruct the array as we also need the offset. When just lengths are supplied, `OffsetArray` falls back to default `Array`s, leading to the bug.