### PR TITLE
Avoid `kw.data`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.34"
+version = "0.2.35"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/name_core.jl
+++ b/src/name_core.jl
@@ -176,7 +176,7 @@ Returns the tuple of index values for an array with `names`, when indexed by key
 Any dimensions not fixed are given as `:`, to make a slice.
 An error is thrown if any keywords are used which do not occur in `nda`'s names.
 """
-order_named_inds(val::Val{L}; kw...) where {L} = order_named_inds(val, kw.data)
+order_named_inds(val::Val{L}; kw...) where {L} = order_named_inds(val, values(kw))
 
 @generated function order_named_inds(val::Val{L}, ni::NamedTuple{K}) where {L,K}
     tuple_issubset(K, L) || throw(DimensionMismatch("Expected subset of $L, got $K"))


### PR DESCRIPTION
This should remove this warning:
```
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = #order_named_inds#17 at name_core.jl:179 [inlined]
└ @ Core ~/.julia/packages/NamedDims/TpffL/src/name_core.jl:179
```