### PR TITLE
2-argument function to help const propagation in broadcasted_names()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.41"
+version = "0.2.42"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -73,10 +73,18 @@ function Base.copyto!(dest::AbstractArray, bc::Broadcasted{NamedDimsStyle{S}}) w
 end
 
 broadcasted_names(bc::Broadcasted) = broadcasted_names(bc.args...)
-function broadcasted_names(a, bs...)
+function broadcasted_names(a, b)
     a_name = broadcasted_names(a)
-    b_name = broadcasted_names(bs...)
+    b_name = broadcasted_names(b)
     return unify_names_longest(a_name, b_name)
+end
+# Including two explicit arguments like this before starting recursion seems to help
+# const-propagation
+function broadcasted_names(a, b, cs...)
+    a_name = broadcasted_names(a)
+    b_name = broadcasted_names(b)
+    c_name = broadcasted_names(cs...)
+    return unify_names_longest(a_name, b_name, c_name)
 end
 broadcasted_names(a::AbstractArray) = dimnames(a)
 broadcasted_names(a) = tuple()

--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -78,7 +78,7 @@ function broadcasted_names(a, b)
     b_name = broadcasted_names(b)
     return unify_names_longest(a_name, b_name)
 end
-# Including two explicit arguments like this before starting recursion seems to help
+# Including two explicit arguments like this before starting recursion helps
 # const-propagation
 function broadcasted_names(a, b, cs...)
     a_name = broadcasted_names(a)

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -149,13 +149,11 @@ function foo(a, b, c, d)
     @. a -= 0.5 * d * b * c
     return a
 end
-if VERSION >= v"1.4"
-    @testset "Regression test against #187 (allocations)" begin
-        # # https://github.com/invenia/NamedDims.jl/issues/187
-        a = NamedDimsArray{(:z,)}(rand(5))
-        b = NamedDimsArray{(:z,)}(rand(5))
-        c = rand()
-        d = rand()
-        @test 0 == @ballocated foo($a, $b, $c, $d)
-    end
+@testset "Regression test against allocations in broadcasting #187" begin
+    # https://github.com/invenia/NamedDims.jl/issues/187
+    a = NamedDimsArray{(:z,)}(rand(5))
+    b = NamedDimsArray{(:z,)}(rand(5))
+    c = rand()
+    d = rand()
+    @test_modern 0 == @ballocated foo($a, $b, $c, $d)
 end

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -149,11 +149,13 @@ function foo(a, b, c, d)
     @. a -= 0.5 * d * b * c
     return a
 end
-@testset "Regression test against #187 (allocations)" begin
-    # # https://github.com/invenia/NamedDims.jl/issues/187
-    a = NamedDimsArray{(:z,)}(rand(5))
-    b = NamedDimsArray{(:z,)}(rand(5))
-    c = rand()
-    d = rand()
-    @test 0 == @ballocated foo($a, $b, $c, $d)
+if VERSION >= v"1.4"
+    @testset "Regression test against #187 (allocations)" begin
+        # # https://github.com/invenia/NamedDims.jl/issues/187
+        a = NamedDimsArray{(:z,)}(rand(5))
+        b = NamedDimsArray{(:z,)}(rand(5))
+        c = rand()
+        d = rand()
+        @test 0 == @ballocated foo($a, $b, $c, $d)
+    end
 end

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -144,3 +144,16 @@ end
     @test ((1,2,3,4) .+ nda) isa NamedDimsArray{(:foo,)}
     @test ((1,2,3,4) .+ nda) == [1, 2, 3, 4]
 end
+
+function foo(a, b, c, d)
+    @. a -= 0.5 * d * b * c
+    return a
+end
+@testset "Regression test against #187 (allocations)" begin
+    # # https://github.com/invenia/NamedDims.jl/issues/187
+    a = NamedDimsArray{(:z,)}(rand(5))
+    b = NamedDimsArray{(:z,)}(rand(5))
+    c = rand()
+    d = rand()
+    @test 0 == @ballocated foo($a, $b, $c, $d)
+end


### PR DESCRIPTION
Apparently less recursion helps the compiler to const-propagate.

Fixes #187.