### PR TITLE
Add Base.convert method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.47"
+version = "0.2.48"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/wrapper_array.jl
+++ b/src/wrapper_array.jl
@@ -62,6 +62,8 @@ dim(a::AbstractArray, d) = d
 NamedDimsVecOrMat{L,T} = Union{NamedDimsArray{L,T,1},NamedDimsArray{L,T,2}}
 NamedDimsVector{L,T} = NamedDimsArray{L,T,1}
 
+Base.convert(::Type{T}, x::Array) where {T<:NamedDimsArray} = T(x)
+
 #############################
 # AbstractArray Interface
 # https://docs.julialang.org/en/v1/manual/interfaces/index.html#man-interface-array-1

--- a/test/wrapper_array.jl
+++ b/test/wrapper_array.jl
@@ -320,3 +320,9 @@ const cnda = NamedDimsArray([10 20; 30 40], (:x, :y))
     @test @ballocated(cnda[x=1]) == @ballocated(cnda[1, :])
     @test 0 == @ballocated cnda[x=1, y=1] = 66
 end
+
+# @testset "convert" begin
+#     nda = NamedDimsArray{(:id, :_)}(rand(5,5))
+#     nda_converted = convert(typeof(nda), rand(5,5))
+#     @test nda_converted isa typeof(nda)
+# end


### PR DESCRIPTION
Simply adds a `Base.convert` method to allow this package to play nicely with another package. All it does is call the constructor. 

```
A = NamedDimsArray{(:id, :_)}(rand(5,5))
convert(typeof(A), rand(5,5)) # Fails
# ERROR: MethodError: Cannot `convert` an object of type Matrix{Float64} to an object of type NamedDimsArray{(:id, :_), Float64, 2, Matrix{Float64}}. Closest candidates are:...
```

The method added is just: 

```
     Base.convert(::Type{T}, x::Array) where {T<:NamedDimsArray} = T(x)
```

Only concrete Arrays are used. Allowing for any AbstractArray was messing up `show`. 

This is emerging in a pipeline i'm working with that calls `oftype` (fwiw: flattening parameters with `ParameterHandling`) [here](https://github.com/invenia/ParameterHandling.jl/blob/21e6ff717cf94ee46175c4ac09bf44cddd0d677f/src/flatten.jl#L55)



