### PR TITLE
Release 1.0 ?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.1"
+version = "1.0.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
This is pretty much stable.
This release will be nonbreaking and the same as the last 0.3.x release which is frustrating but still better I think than leaving this 0.x forever.

Though maybe this isn't as stable as i thought, why did we release 0.3?

Invenia's new  internal policy is to create packages at 1.0.0 and never use  0.x.y versioning