### PR TITLE
Release HEAD as 0.2 since 0.3 was nonbreaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.2"
+version = "0.2.50"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
Since the 0.3 was non-breaking https://github.com/invenia/NamedDims.jl/pull/202#discussion_r937572855

we can probably do this and avoid changing all the compats everywhere