### PR TITLE
infer reduce(*cat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -68,7 +68,7 @@ for (f, nf, tf, tup) in
             return $nf(mapreduce(dimnames, unify_names_longest, A), A)
         end
 
-        function $nf(Linner, A)
+        @inline function $nf(Linner, A)
             Louter = ($tup..., dimnames(A)...)
             Lnew = unify_names_longest(Linner, Louter)
             data = Base.$tf(mapreduce(eltype, promote_type, A), A) # same as Base

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -95,8 +95,8 @@ for (f, d) in zip((vcat, hcat), (1, 2))
         end
 
         @testset "reduce forms" begin
-            @test reduce(f, [nda, nda]) == f(nda, nda)
-            @test reduce(f, [ndv, ndv]) == f(ndv, ndv)
+            @test @inferred(reduce(f, [nda, nda])) == f(nda, nda)
+            @test @inferred(reduce(f, [ndv, ndv])) == f(ndv, ndv)
 
             v1 = NamedDimsArray([a, a], dimnames(nda, d))
             v2 = NamedDimsArray([a, nda, a, nda], dimnames(nda, d))


### PR DESCRIPTION
`_named_*cat` funcs rely on constant propagation of names, so they need inlining to infer
